### PR TITLE
Convert testing scripts into pytest suites

### DIFF
--- a/tests/test_banco_workflow.py
+++ b/tests/test_banco_workflow.py
@@ -1,0 +1,42 @@
+import os
+import tempfile
+import unittest
+
+import database
+
+
+class TestBancoWorkflow(unittest.TestCase):
+    def setUp(self):
+        fd, self.temp_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+        self.orig = database.DB_PATH
+        database.DB_PATH = self.temp_path
+        database.inicializar_banco()
+
+    def tearDown(self):
+        database.DB_PATH = self.orig
+        if os.path.exists(self.temp_path):
+            os.remove(self.temp_path)
+
+    def test_workflow(self):
+        usuarios = database.buscar_usuarios()
+        nomes = [u[1] for u in usuarios]
+        if 'Pedro' not in nomes:
+            database.criar_usuario('Pedro', 'Masculino')
+        if 'Isabella' not in nomes:
+            database.criar_usuario('Isabella', 'Feminino')
+
+        usuarios = database.buscar_usuarios()
+        nomes = [u[1] for u in usuarios]
+        self.assertIn('Pedro', nomes)
+        self.assertIn('Isabella', nomes)
+
+        pedro_id = next(u[0] for u in usuarios if u[1] == 'Pedro')
+        database.salvar_ideia(pedro_id, 'Criar versao web')
+        ideias = database.listar_ideias(pedro_id)
+        self.assertEqual(len(ideias), 1)
+        self.assertEqual(ideias[0][0], 'Criar versao web')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -1,0 +1,47 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch, Mock
+
+# Provide a minimal 'requests' stub if the real library is unavailable.
+if 'requests' not in sys.modules:
+    requests_stub = types.ModuleType('requests')
+    class ConnError(Exception):
+        pass
+    requests_stub.exceptions = types.SimpleNamespace(ConnectionError=ConnError)
+    requests_stub.post = lambda *a, **k: None
+    sys.modules['requests'] = requests_stub
+
+import llm_interface
+
+
+class TestGerarResposta(unittest.TestCase):
+    @patch('llm_interface.requests.post')
+    def test_resposta_sucesso(self, mock_post):
+        mock_response = Mock()
+        mock_response.json.return_value = {"response": "ok"}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        result = llm_interface.gerar_resposta("Oi?")
+        self.assertEqual(result, "ok")
+
+    @patch('llm_interface.requests.post')
+    def test_falha_conexao(self, mock_post):
+        mock_post.side_effect = llm_interface.requests.exceptions.ConnectionError("falha")
+        result = llm_interface.gerar_resposta("Oi?")
+        self.assertTrue(result.startswith("[FALHA]"))
+
+    @patch('llm_interface.requests.post')
+    def test_resposta_inesperada(self, mock_post):
+        mock_response = Mock()
+        mock_response.json.return_value = {"foo": "bar"}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        result = llm_interface.gerar_resposta("Oi?")
+        self.assertEqual(result, "[ERRO] Sem resposta do modelo")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add test coverage for LLM interface with mocked success and failure cases
- add workflow test converting testar_banco.py script actions

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600b1b392c832c9a5590d9498480d3