### PR TITLE
Package core and update imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ollama serve
 O modo em linha de comando inicia o fluxo principal da aplicação:
 
 ```bash
-python main.py
+python -m Hermes.main
 ```
 
 ## Executando a interface gráfica
@@ -35,7 +35,7 @@ python main.py
 Para abrir a interface gráfica (PyQt5):
 
 ```bash
-python gui_ideias.py
+python -m Hermes.gui_ideias
 ```
 
 ## Testes
@@ -44,6 +44,6 @@ Os testes automatizados utilizam o módulo `unittest` padrão do Python.
 Execute todos eles com:
 
 ```bash
-python -m unittest discover -s tests
+python -m unittest discover -s Hermes/tests
 ```
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+"""Hermes package initialization."""

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core functionality of Hermes."""

--- a/core/registro_ideias.py
+++ b/core/registro_ideias.py
@@ -1,9 +1,7 @@
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+"""Registro de ideias utilizando o modelo de linguagem."""
 
-from database import salvar_ideia
-from llm_interface import gerar_resposta
+from ..database import salvar_ideia
+from ..llm_interface import gerar_resposta
 
 def registrar_ideia_com_llm(usuario_id: int, titulo: str, descricao: str):
     print(f"Registrando ideia: {titulo}")

--- a/gui_ideias.py
+++ b/gui_ideias.py
@@ -3,7 +3,7 @@ from PyQt5.QtWidgets import (
     QApplication, QWidget, QLabel, QLineEdit, QTextEdit,
     QPushButton, QVBoxLayout, QComboBox, QMessageBox, QListWidget, QListWidgetItem
 )
-from database import buscar_usuarios, salvar_ideia, listar_ideias
+from .database import buscar_usuarios, salvar_ideia, listar_ideias
 
 class HermesGUI(QWidget):
     def __init__(self):

--- a/main.py
+++ b/main.py
@@ -1,5 +1,11 @@
-from database import inicializar_banco, buscar_usuarios, criar_usuario, salvar_ideia, listar_ideias
-from core.registro_ideias import registrar_ideia_com_llm
+from .database import (
+    inicializar_banco,
+    buscar_usuarios,
+    criar_usuario,
+    salvar_ideia,
+    listar_ideias,
+)
+from .core.registro_ideias import registrar_ideia_com_llm
 
 def escolher_usuario():
     usuarios = buscar_usuarios()

--- a/testar_banco.py
+++ b/testar_banco.py
@@ -1,4 +1,10 @@
-from database import inicializar_banco, criar_usuario, buscar_usuarios, salvar_ideia, listar_ideias
+from .database import (
+    inicializar_banco,
+    criar_usuario,
+    buscar_usuarios,
+    salvar_ideia,
+    listar_ideias,
+)
 
 # Inicializa banco e tabelas
 inicializar_banco()

--- a/testar_llm.py
+++ b/testar_llm.py
@@ -1,4 +1,4 @@
-from llm_interface import gerar_resposta
+from .llm_interface import gerar_resposta
 
 pergunta = "Explique brevemente o que é inteligência artificial."
 resposta = gerar_resposta(pergunta)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure the parent directory is on the path so the Hermes package can be imported.
+sys.path.append(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)

--- a/tests/test_banco_workflow.py
+++ b/tests/test_banco_workflow.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest
 
-import database
+from Hermes import database
 
 
 class TestBancoWorkflow(unittest.TestCase):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest
 
-import database
+from Hermes import database
 
 
 class TestDatabase(unittest.TestCase):

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -12,11 +12,11 @@ if 'requests' not in sys.modules:
     requests_stub.post = lambda *a, **k: None
     sys.modules['requests'] = requests_stub
 
-import llm_interface
+from Hermes import llm_interface
 
 
 class TestGerarResposta(unittest.TestCase):
-    @patch('llm_interface.requests.post')
+    @patch('Hermes.llm_interface.requests.post')
     def test_resposta_sucesso(self, mock_post):
         mock_response = Mock()
         mock_response.json.return_value = {"response": "ok"}
@@ -26,13 +26,13 @@ class TestGerarResposta(unittest.TestCase):
         result = llm_interface.gerar_resposta("Oi?")
         self.assertEqual(result, "ok")
 
-    @patch('llm_interface.requests.post')
+    @patch('Hermes.llm_interface.requests.post')
     def test_falha_conexao(self, mock_post):
         mock_post.side_effect = llm_interface.requests.exceptions.ConnectionError("falha")
         result = llm_interface.gerar_resposta("Oi?")
         self.assertTrue(result.startswith("[FALHA]"))
 
-    @patch('llm_interface.requests.post')
+    @patch('Hermes.llm_interface.requests.post')
     def test_resposta_inesperada(self, mock_post):
         mock_response = Mock()
         mock_response.json.return_value = {"foo": "bar"}


### PR DESCRIPTION
## Summary
- make `core` a proper package and remove manual `sys.path` manipulation
- switch project modules to package-relative imports and module execution
- document new `python -m Hermes.*` entry points and adjust tests for package layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af073587a8832c81c661827d920245