### PR TITLE
Allow configuring LLM endpoint and model

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ o [Ollama](https://github.com/jmorganca/ollama) localmente:
 ollama serve
 ```
 
+### Configuração
+
+O endpoint e o modelo utilizados podem ser personalizados pelas variáveis
+de ambiente:
+
+- `LLM_URL` – URL do endpoint de geração (padrão:
+  `http://localhost:11434/api/generate`)
+- `LLM_MODEL` – nome do modelo a ser utilizado (padrão: `mistral`)
+
+Esses valores também podem ser informados diretamente ao chamar a função
+`gerar_resposta`:
+
+```python
+from Hermes.llm_interface import gerar_resposta
+resposta = gerar_resposta("Oi?", url="http://meu-servidor:port/api/generate", model="outro-modelo")
+```
+
 ## Executando o CLI
 
 O modo em linha de comando inicia o fluxo principal da aplicação:

--- a/core/registro_ideias.py
+++ b/core/registro_ideias.py
@@ -3,7 +3,13 @@
 from ..database import salvar_ideia
 from ..llm_interface import gerar_resposta
 
-def registrar_ideia_com_llm(usuario_id: int, titulo: str, descricao: str):
+def registrar_ideia_com_llm(
+    usuario_id: int,
+    titulo: str,
+    descricao: str,
+    url: str | None = None,
+    model: str | None = None,
+):
     print(f"Registrando ideia: {titulo}")
     print("Enviando ideia ao modelo para sugestões...")
 
@@ -18,7 +24,7 @@ Tema: <tema>
 Resumo: <resumo>
 """
 
-    resposta = gerar_resposta(prompt)
+    resposta = gerar_resposta(prompt, url=url, model=model)
     print("Resposta do modelo:")
     print(resposta)
 

--- a/llm_interface.py
+++ b/llm_interface.py
@@ -1,11 +1,31 @@
+"""Interface de comunicação com o modelo de linguagem."""
+
+import os
 import requests
 
-def gerar_resposta(prompt: str) -> str:
+def gerar_resposta(prompt: str, url: str | None = None, model: str | None = None) -> str:
+    """Envia um *prompt* ao servidor LLM e retorna a resposta.
+
+    Parameters
+    ----------
+    prompt: str
+        Texto a ser enviado ao modelo.
+    url: str | None, optional
+        URL do endpoint de geração. Se não for informado, é lido da
+        variável de ambiente ``LLM_URL`` ou utiliza ``http://localhost:11434/api/generate``.
+    model: str | None, optional
+        Nome do modelo a ser utilizado. Se não for informado, é lido da
+        variável de ambiente ``LLM_MODEL`` ou utiliza ``mistral``.
+    """
+
+    url = url or os.getenv("LLM_URL", "http://localhost:11434/api/generate")
+    model = model or os.getenv("LLM_MODEL", "mistral")
+
     try:
         response = requests.post(
-            "http://localhost:11434/api/generate",
-            json={"model": "mistral", "prompt": prompt, "stream": False},
-            timeout=30
+            url,
+            json={"model": model, "prompt": prompt, "stream": False},
+            timeout=30,
         )
         response.raise_for_status()
         dados = response.json()

--- a/testar_llm.py
+++ b/testar_llm.py
@@ -1,6 +1,12 @@
+import os
+
 from .llm_interface import gerar_resposta
 
 pergunta = "Explique brevemente o que é inteligência artificial."
-resposta = gerar_resposta(pergunta)
+resposta = gerar_resposta(
+    pergunta,
+    url=os.getenv("LLM_URL"),
+    model=os.getenv("LLM_MODEL"),
+)
 print("Resposta do modelo:")
 print(resposta)

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -23,13 +23,17 @@ class TestGerarResposta(unittest.TestCase):
         mock_response.raise_for_status.return_value = None
         mock_post.return_value = mock_response
 
-        result = llm_interface.gerar_resposta("Oi?")
+        result = llm_interface.gerar_resposta(
+            "Oi?", url="http://test", model="fake"
+        )
         self.assertEqual(result, "ok")
 
     @patch('Hermes.llm_interface.requests.post')
     def test_falha_conexao(self, mock_post):
         mock_post.side_effect = llm_interface.requests.exceptions.ConnectionError("falha")
-        result = llm_interface.gerar_resposta("Oi?")
+        result = llm_interface.gerar_resposta(
+            "Oi?", url="http://test", model="fake"
+        )
         self.assertTrue(result.startswith("[FALHA]"))
 
     @patch('Hermes.llm_interface.requests.post')
@@ -39,7 +43,9 @@ class TestGerarResposta(unittest.TestCase):
         mock_response.raise_for_status.return_value = None
         mock_post.return_value = mock_response
 
-        result = llm_interface.gerar_resposta("Oi?")
+        result = llm_interface.gerar_resposta(
+            "Oi?", url="http://test", model="fake"
+        )
         self.assertEqual(result, "[ERRO] Sem resposta do modelo")
 
 


### PR DESCRIPTION
## Summary
- allow passing or environment configuration for LLM URL and model in `gerar_resposta`
- expose optional parameters in idea registration and demo scripts
- document LLM_URL and LLM_MODEL usage

## Testing
- `python -m unittest discover -s Hermes/tests`


------
https://chatgpt.com/codex/tasks/task_e_68af09375d90832cad768ba4d0d21cb2