### PR TITLE
Ensure CLI exits cleanly

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import sys
+
 from .database import (
     inicializar_banco,
     buscar_usuarios,
@@ -55,7 +57,7 @@ def menu_principal(usuario_id, nome_usuario):
             return True  # trocar de usuário
         elif opcao == "4":
             print("Encerrando Hermes.")
-            exit()
+            return False
         else:
             print("Opção inválida.")
 
@@ -66,6 +68,7 @@ def main():
         nome_usuario = next((u[1] for u in buscar_usuarios() if u[0] == usuario_id), "Desconhecido")
         if not menu_principal(usuario_id, nome_usuario):
             break
+    return 0
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,27 @@
+import runpy
+import sys
+import unittest
+from unittest.mock import patch
+
+from Hermes import main as cli
+
+
+class TestCLI(unittest.TestCase):
+    def test_menu_principal_quit_returns_false(self):
+        with patch("builtins.input", side_effect=["4"]):
+            result = cli.menu_principal(1, "User")
+        self.assertFalse(result)
+
+    def test_main_exits_cleanly(self):
+        inputs = iter(["1", "4"])
+        with patch("Hermes.database.inicializar_banco"), \
+             patch("Hermes.database.buscar_usuarios", return_value=[(1, "User", "M")]), \
+             patch("builtins.input", lambda _: next(inputs)):
+            sys.modules.pop("Hermes.main", None)
+            with self.assertRaises(SystemExit) as cm:
+                runpy.run_module("Hermes.main", run_name="__main__")
+        self.assertEqual(cm.exception.code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace `exit()` with a return code and handle process termination via `sys.exit`
- Break `main()` loop cleanly on user exit
- Add unit tests verifying controlled CLI termination

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af0b4dd9b8832cb1abed23c394c14d