### PR TITLE
Add tests for idea registration and CLI interactions

### DIFF
--- a/tests/test_menu_principal_integration.py
+++ b/tests/test_menu_principal_integration.py
@@ -1,0 +1,36 @@
+import io
+import unittest
+from unittest.mock import patch
+
+from Hermes import main
+
+
+class TestMenuPrincipalIntegration(unittest.TestCase):
+    def test_registra_ideia_fluxo(self):
+        inputs = iter(["1", "Minha ideia", "4"])
+        with patch.object(main, "salvar_ideia") as mock_salvar, \
+             patch("builtins.input", lambda _: next(inputs)), \
+             patch("sys.stdout", new_callable=io.StringIO) as fake_out:
+            result = main.menu_principal(1, "User")
+
+        self.assertFalse(result)
+        mock_salvar.assert_called_once_with(1, "Minha ideia")
+        saida = fake_out.getvalue()
+        self.assertIn("Ideia registrada", saida)
+
+    def test_listar_ideias_fluxo(self):
+        inputs = iter(["2", "4"])
+        ideias = [("Texto", "2024-01-01")]
+        with patch.object(main, "listar_ideias", return_value=ideias), \
+             patch("builtins.input", lambda _: next(inputs)), \
+             patch("sys.stdout", new_callable=io.StringIO) as fake_out:
+            result = main.menu_principal(1, "User")
+
+        self.assertFalse(result)
+        saida = fake_out.getvalue()
+        self.assertIn("Minhas ideias", saida)
+        self.assertIn("[2024-01-01] Texto", saida)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_registro_ideias.py
+++ b/tests/test_registro_ideias.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch
+
+from Hermes.core.registro_ideias import registrar_ideia_com_llm
+
+
+class TestRegistrarIdeiaComLLM(unittest.TestCase):
+    def test_registra_ideia_usa_llm_e_salva(self):
+        usuario_id = 1
+        titulo = "Titulo"
+        descricao = "Descricao"
+        url = "http://mock"
+        model = "fake-model"
+
+        with patch("Hermes.core.registro_ideias.gerar_resposta", return_value="Tema: X\nResumo: Y") as mock_llm, \
+             patch("Hermes.core.registro_ideias.salvar_ideia") as mock_salvar, \
+             patch("builtins.print"):
+            registrar_ideia_com_llm(usuario_id, titulo, descricao, url=url, model=model)
+
+        mock_llm.assert_called_once()
+        prompt = mock_llm.call_args.args[0]
+        self.assertIn(titulo, prompt)
+        self.assertIn(descricao, prompt)
+        self.assertEqual(mock_llm.call_args.kwargs["url"], url)
+        self.assertEqual(mock_llm.call_args.kwargs["model"], model)
+
+        mock_salvar.assert_called_once_with(usuario_id, f"{titulo}\n\n{descricao}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add unit test for registrar_ideia_com_llm ensuring proper LLM call and DB save
- Add integration-style tests for menu_principal simulating registration and listing flows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0d42dd6c832c915deecbc8c9fb9d