### PR TITLE
Trim unused dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ pip install -r requirements.txt
 
 Isso instalará também a dependência `requests` utilizada pelo projeto.
 
+### Dependências opcionais
+
+Algumas funcionalidades futuras podem requerer bibliotecas adicionais que não
+estão incluídas na instalação padrão:
+
+- `vosk` – reconhecimento de fala.
+- `ollama` – cliente Python para o servidor Ollama.
+
+Instale-as manualmente caso deseje experimentar esses recursos.
+
 ## Servidor LLM
 
 Para funcionalidades que usam o modelo de linguagem é necessário que um

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-vosk==0.3.45
 PyQt5==5.15.9
-ollama==0.1.0
 requests
+
+# Optional dependencies for future features (not required for basic usage):
+# vosk==0.3.45    # speech recognition
+# ollama==0.1.0   # Python client for local LLM server


### PR DESCRIPTION
## Summary
- remove unused `vosk` and `ollama` from core requirements
- document optional dependencies for future features

## Testing
- `python -m venv /tmp/hermes_env`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement PyQt5==5.15.9)*
- `PYTHONPATH=.. python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68af0f9b7014832c98428f28b51f6e69