### PR TITLE
Use LLM in menu idea registration

### DIFF
--- a/core/registro_ideias.py
+++ b/core/registro_ideias.py
@@ -9,7 +9,7 @@ def registrar_ideia_com_llm(
     descricao: str,
     url: str | None = None,
     model: str | None = None,
-):
+) -> str:
     print(f"Registrando ideia: {titulo}")
     print("Enviando ideia ao modelo para sugestões...")
 
@@ -25,10 +25,11 @@ Resumo: <resumo>
 """
 
     resposta = gerar_resposta(prompt, url=url, model=model)
-    print("Resposta do modelo:")
-    print(resposta)
+    if resposta.startswith("[FALHA]"):
+        raise RuntimeError(resposta)
 
     salvar_ideia(usuario_id, f"{titulo}\n\n{descricao}")
+    return resposta
 
 if __name__ == "__main__":
     usuario_id = 1  # Pedro

--- a/main.py
+++ b/main.py
@@ -42,9 +42,20 @@ def menu_principal(usuario_id, nome_usuario):
         opcao = input("Escolha uma opção: ")
 
         if opcao == "1":
-            texto = input("Digite sua ideia: ")
-            salvar_ideia(usuario_id, texto)
-            print("✅ Ideia registrada.")
+            titulo = input("Título da ideia: ")
+            descricao = input("Descrição da ideia: ")
+            try:
+                sugestoes = registrar_ideia_com_llm(usuario_id, titulo, descricao)
+                print("✅ Ideia registrada.")
+                print("Sugestões do modelo:")
+                print(sugestoes)
+            except RuntimeError as e:
+                print(f"⚠️ {e}")
+                if input("Deseja salvar a ideia mesmo assim? (s/N): ").strip().lower() == "s":
+                    salvar_ideia(usuario_id, f"{titulo}\n\n{descricao}")
+                    print("✅ Ideia registrada sem sugestões.")
+                else:
+                    print("❌ Ideia não registrada.")
         elif opcao == "2":
             ideias = listar_ideias(usuario_id)
             if ideias:

--- a/tests/test_menu_principal_integration.py
+++ b/tests/test_menu_principal_integration.py
@@ -7,16 +7,31 @@ from Hermes import main
 
 class TestMenuPrincipalIntegration(unittest.TestCase):
     def test_registra_ideia_fluxo(self):
-        inputs = iter(["1", "Minha ideia", "4"])
-        with patch.object(main, "salvar_ideia") as mock_salvar, \
+        inputs = iter(["1", "Titulo", "Descricao", "4"])
+        with patch.object(main, "registrar_ideia_com_llm", return_value="Tema: X\nResumo: Y") as mock_registrar, \
              patch("builtins.input", lambda _: next(inputs)), \
              patch("sys.stdout", new_callable=io.StringIO) as fake_out:
             result = main.menu_principal(1, "User")
 
         self.assertFalse(result)
-        mock_salvar.assert_called_once_with(1, "Minha ideia")
+        mock_registrar.assert_called_once_with(1, "Titulo", "Descricao")
         saida = fake_out.getvalue()
         self.assertIn("Ideia registrada", saida)
+        self.assertIn("Sugestões do modelo", saida)
+        self.assertIn("Tema: X", saida)
+
+    def test_registra_sem_llm_quando_indisponivel(self):
+        inputs = iter(["1", "Titulo", "Descricao", "s", "4"])
+        with patch.object(main, "registrar_ideia_com_llm", side_effect=RuntimeError("falha")), \
+             patch.object(main, "salvar_ideia") as mock_salvar, \
+             patch("builtins.input", lambda _: next(inputs)), \
+             patch("sys.stdout", new_callable=io.StringIO) as fake_out:
+            result = main.menu_principal(1, "User")
+
+        self.assertFalse(result)
+        mock_salvar.assert_called_once_with(1, "Titulo\n\nDescricao")
+        saida = fake_out.getvalue()
+        self.assertIn("Ideia registrada sem sugestões", saida)
 
     def test_listar_ideias_fluxo(self):
         inputs = iter(["2", "4"])

--- a/tests/test_registro_ideias.py
+++ b/tests/test_registro_ideias.py
@@ -15,7 +15,7 @@ class TestRegistrarIdeiaComLLM(unittest.TestCase):
         with patch("Hermes.core.registro_ideias.gerar_resposta", return_value="Tema: X\nResumo: Y") as mock_llm, \
              patch("Hermes.core.registro_ideias.salvar_ideia") as mock_salvar, \
              patch("builtins.print"):
-            registrar_ideia_com_llm(usuario_id, titulo, descricao, url=url, model=model)
+            resposta = registrar_ideia_com_llm(usuario_id, titulo, descricao, url=url, model=model)
 
         mock_llm.assert_called_once()
         prompt = mock_llm.call_args.args[0]
@@ -25,6 +25,21 @@ class TestRegistrarIdeiaComLLM(unittest.TestCase):
         self.assertEqual(mock_llm.call_args.kwargs["model"], model)
 
         mock_salvar.assert_called_once_with(usuario_id, f"{titulo}\n\n{descricao}")
+        self.assertEqual(resposta, "Tema: X\nResumo: Y")
+
+    def test_falha_llm_gera_excecao(self):
+        usuario_id = 1
+        titulo = "Titulo"
+        descricao = "Descricao"
+
+        with patch("Hermes.core.registro_ideias.gerar_resposta", return_value="[FALHA] erro") as mock_llm, \
+             patch("Hermes.core.registro_ideias.salvar_ideia") as mock_salvar, \
+             patch("builtins.print"):
+            with self.assertRaises(RuntimeError):
+                registrar_ideia_com_llm(usuario_id, titulo, descricao)
+
+        mock_llm.assert_called_once()
+        mock_salvar.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Route idea registration through `core.registro_ideias.registrar_ideia_com_llm` in the CLI menu
- Allow skipping LLM suggestions when the LLM server is unavailable
- Expand tests to cover LLM suggestion flow and fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af11830e48832c97dc690b04e8bb5a