### PR TITLE
feat: central configuration for Hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,20 @@ ollama serve
 
 ### Configuração
 
-O endpoint e o modelo utilizados podem ser personalizados pelas variáveis
-de ambiente:
+Os principais parâmetros da aplicação podem ser ajustados via variáveis de
+ambiente ou argumentos de linha de comando. Valores padrão:
 
-- `LLM_URL` – URL do endpoint de geração (padrão:
-  `http://localhost:11434/api/generate`)
-- `LLM_MODEL` – nome do modelo a ser utilizado (padrão: `mistral`)
+| Parâmetro       | Variável de ambiente     | Argumento CLI     | Padrão                  |
+|-----------------|--------------------------|-------------------|-------------------------|
+| Caminho do banco| `HERMES_DB_PATH`         | `--db-path`       | `hermes.db`             |
+| Porta do servidor LLM | `HERMES_API_PORT`   | `--api-port`      | `11434`                 |
+| Modelo Ollama   | `HERMES_OLLAMA_MODEL`    | `--ollama-model`  | `mistral`               |
+| Timeout (s)     | `HERMES_TIMEOUT`         | `--timeout`       | `30`                    |
+
+O endpoint utilizado para comunicação com o LLM é construído a partir da
+porta (`http://localhost:<porta>/api/generate`). Os argumentos de linha de
+comando podem ser passados ao executar `python -m hermes` ou `python -m
+hermes.ui.cli`.
 
 Esses valores também podem ser informados diretamente ao chamar a função
 `gerar_resposta`:

--- a/hermes/__init__.py
+++ b/hermes/__init__.py
@@ -1,4 +1,6 @@
 """Top-level package for Hermes."""
 
-__all__ = ["core", "ui", "services", "data"]
+from . import config
+
+__all__ = ["core", "ui", "services", "data", "config"]
 __version__ = "0.1.0"

--- a/hermes/__main__.py
+++ b/hermes/__main__.py
@@ -1,10 +1,12 @@
 """Entrypoint for running Hermes as a module."""
 
+from .config import load_from_args
 from .ui import gui
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     """Launch the graphical user interface."""
+    load_from_args(argv)
     gui.main()
 
 

--- a/hermes/config.py
+++ b/hermes/config.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Central configuration for Hermes.
+
+This module exposes a global :data:`config` instance whose values can be
+customised via environment variables or command-line arguments.
+"""
+
+from dataclasses import dataclass
+import os
+import argparse
+from typing import Sequence
+
+
+@dataclass
+class Config:
+    """Holds application configuration values."""
+
+    DB_PATH: str = "hermes.db"
+    API_PORT: int = 11434
+    OLLAMA_MODEL: str = "mistral"
+    TIMEOUT: int = 30  # seconds
+
+
+def _from_env() -> Config:
+    """Create a :class:`Config` instance from environment variables."""
+    return Config(
+        DB_PATH=os.getenv("HERMES_DB_PATH", Config.DB_PATH),
+        API_PORT=int(os.getenv("HERMES_API_PORT", Config.API_PORT)),
+        OLLAMA_MODEL=os.getenv("HERMES_OLLAMA_MODEL", Config.OLLAMA_MODEL),
+        TIMEOUT=int(os.getenv("HERMES_TIMEOUT", Config.TIMEOUT)),
+    )
+
+
+config = _from_env()
+
+
+def load_from_args(args: Sequence[str] | None = None) -> Config:
+    """Update :data:`config` using command-line arguments.
+
+    Parameters
+    ----------
+    args: Sequence[str] | None
+        Argument list (excluding the program name). If ``None`` the current
+        ``sys.argv`` is used.
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--db-path")
+    parser.add_argument("--api-port", type=int)
+    parser.add_argument("--ollama-model")
+    parser.add_argument("--timeout", type=int)
+
+    namespace, _ = parser.parse_known_args(args)
+
+    global config
+    config = Config(
+        DB_PATH=namespace.db_path or config.DB_PATH,
+        API_PORT=namespace.api_port or config.API_PORT,
+        OLLAMA_MODEL=namespace.ollama_model or config.OLLAMA_MODEL,
+        TIMEOUT=namespace.timeout or config.TIMEOUT,
+    )
+    return config

--- a/hermes/data/database.py
+++ b/hermes/data/database.py
@@ -1,7 +1,11 @@
 import sqlite3
 from datetime import datetime
 
-DB_PATH = "hermes.db"
+from ..config import config
+
+# Allow tests to monkeypatch ``DB_PATH`` directly while defaulting to the
+# value provided by :mod:`hermes.config`.
+DB_PATH = config.DB_PATH
 
 def conectar():
     return sqlite3.connect(DB_PATH)

--- a/hermes/services/llm_interface.py
+++ b/hermes/services/llm_interface.py
@@ -1,9 +1,16 @@
 """Interface de comunicação com o modelo de linguagem."""
 
-import os
 import requests
 
-def gerar_resposta(prompt: str, url: str | None = None, model: str | None = None) -> str:
+from ..config import config
+
+
+def gerar_resposta(
+    prompt: str,
+    url: str | None = None,
+    model: str | None = None,
+    timeout: int | None = None,
+) -> str:
     """Envia um *prompt* ao servidor LLM e retorna a resposta.
 
     Parameters
@@ -11,21 +18,25 @@ def gerar_resposta(prompt: str, url: str | None = None, model: str | None = None
     prompt: str
         Texto a ser enviado ao modelo.
     url: str | None, optional
-        URL do endpoint de geração. Se não for informado, é lido da
-        variável de ambiente ``LLM_URL`` ou utiliza ``http://localhost:11434/api/generate``.
+        URL do endpoint de geração. Se ``None``, utiliza ``localhost`` com a
+        porta definida em :mod:`hermes.config`.
     model: str | None, optional
-        Nome do modelo a ser utilizado. Se não for informado, é lido da
-        variável de ambiente ``LLM_MODEL`` ou utiliza ``mistral``.
+        Nome do modelo a ser utilizado. Se ``None``, utiliza o valor de
+        :mod:`hermes.config`.
+    timeout: int | None, optional
+        Tempo máximo (em segundos) de espera pela resposta. Se ``None``, usa o
+        valor de :mod:`hermes.config`.
     """
 
-    url = url or os.getenv("LLM_URL", "http://localhost:11434/api/generate")
-    model = model or os.getenv("LLM_MODEL", "mistral")
+    url = url or f"http://localhost:{config.API_PORT}/api/generate"
+    model = model or config.OLLAMA_MODEL
+    timeout = timeout or config.TIMEOUT
 
     try:
         response = requests.post(
             url,
             json={"model": model, "prompt": prompt, "stream": False},
-            timeout=30,
+            timeout=timeout,
         )
         response.raise_for_status()
         dados = response.json()

--- a/hermes/ui/cli.py
+++ b/hermes/ui/cli.py
@@ -1,5 +1,6 @@
 import sys
 
+from ..config import load_from_args
 from ..data.database import (
     inicializar_banco,
     buscar_usuarios,
@@ -72,7 +73,8 @@ def menu_principal(usuario_id, nome_usuario):
         else:
             print("Opção inválida.")
 
-def main():
+def main(argv: list[str] | None = None):
+    load_from_args(argv)
     inicializar_banco()
     while True:
         usuario_id = escolher_usuario()


### PR DESCRIPTION
## Summary
- centralize runtime parameters in a new `hermes.config` module
- consume configuration in database, LLM interface and entrypoints
- document configurable parameters and defaults

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1b0b91380832c8c0b961f3cd2a01e