### PR TITLE
Add contributing guide, changelog, and MIT license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
+
+O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/),
+e este projeto adere à [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-08-29
+### Adicionado
+- Versão inicial.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contribuindo
+
+Agradecemos seu interesse em contribuir com o Hermes!
+
+## Fluxo de Pull Request
+
+1. Faça um fork deste repositório e crie um branch para sua feature ou correção.
+2. Garanta que testes e linters passem antes de enviar suas alterações.
+3. Abra um Pull Request descrevendo claramente suas modificações.
+
+## Ambiente de desenvolvimento
+
+Instale o pacote em modo editável e as ferramentas de desenvolvimento:
+
+```bash
+pip install -e .
+pip install pre-commit
+pre-commit install
+```
+
+## Testes
+
+Execute a suíte de testes completa:
+
+```bash
+python -m unittest discover -s tests
+```
+
+## Linters
+
+Execute os linters localmente antes de commitar:
+
+```bash
+pre-commit run --files <arquivos_modificados>
+```
+
+Obrigado por ajudar a melhorar o projeto!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Hermes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,19 @@
 
 Assistente pessoal modular, privado e offline com múltiplos usuários, interface visual, entrada por voz/texto e integração com LLM local.
 
-## Instalação das dependências
+## Instalação
 
-Use o `pip` para instalar os pacotes listados em `requirements.txt`:
+Instale o Hermes em modo editável para desenvolver ou executar localmente:
+
+```bash
+pip install -e .
+```
+
+Caso deseje instalar apenas as dependências listadas, utilize `requirements.txt`:
 
 ```bash
 pip install -r requirements.txt
 ```
-
-Isso instalará também a dependência `requests` utilizada pelo projeto.
 
 ### Dependências opcionais
 
@@ -57,16 +61,16 @@ from hermes.services.llm_interface import gerar_resposta
 resposta = gerar_resposta("Oi?", url="http://meu-servidor:port/api/generate", model="outro-modelo")
 ```
 
-## Executando o CLI
+## Execução
 
+### CLI
 O modo em linha de comando inicia o fluxo principal da aplicação:
 
 ```bash
 python -m hermes.ui.cli
 ```
 
-## Executando a interface gráfica
-
+### Interface gráfica
 Para abrir a interface gráfica (PyQt5):
 
 ```bash
@@ -81,4 +85,17 @@ Execute todos eles com:
 ```bash
 python -m unittest discover -s tests
 ```
+
+## Desenvolvimento
+
+Instale e configure os linters com [pre-commit](https://pre-commit.com/):
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Consulte também [CONTRIBUTING.md](CONTRIBUTING.md) para o fluxo de contribuição,
+[CHANGELOG.md](CHANGELOG.md) para o histórico de mudanças e
+[LICENSE](LICENSE) para os termos de licença.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "hermes"
 version = "0.1.0"
 description = "Hermes - Registro de ideias com LLM"
 readme = "README.md"
+license = {file = "LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
     "PyQt5>=5.15.9",
@@ -27,3 +28,8 @@ line_length = 88
 [tool.ruff]
 line-length = 88
 target-version = "py310"
+
+[project.urls]
+"Changelog" = "CHANGELOG.md"
+"Contributing" = "CONTRIBUTING.md"
+"License" = "LICENSE"


### PR DESCRIPTION
## Summary
- document editable installation, execution, and development steps
- add MIT license, contributing guide, and changelog
- reference documentation files in project metadata

## Testing
- `python -m unittest discover -s tests`
- `pre-commit run --files README.md pyproject.toml CHANGELOG.md CONTRIBUTING.md LICENSE` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d16c4edc832c8afa81fb33e66183