### PR TITLE
Refactor logging setup and remove redundant configuration

### DIFF
--- a/hermes/logging.py
+++ b/hermes/logging.py
@@ -11,6 +11,10 @@ def setup_logging() -> None:
     """Configure application logging."""
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)
+
+    # Close any existing handlers before reconfiguring
+    for handler in root_logger.handlers:
+        handler.close()
     root_logger.handlers.clear()
 
     LOG_DIR.mkdir(parents=True, exist_ok=True)

--- a/hermes/ui/cli.py
+++ b/hermes/ui/cli.py
@@ -40,7 +40,6 @@ def escolher_usuario():
 
 
 def menu_principal(usuario_id, nome_usuario):
-    setup_logging()
     while True:
         logger.info("\n=== Hermes (Usuário: %s) ===", nome_usuario)
         logger.info("1. Registrar nova ideia")

--- a/tests/test_menu_principal_integration.py
+++ b/tests/test_menu_principal_integration.py
@@ -15,6 +15,7 @@ class TestMenuPrincipalIntegration(unittest.TestCase):
             patch("builtins.input", lambda _: next(inputs)),
             patch("sys.stdout", new_callable=io.StringIO) as fake_out,
         ):
+            main.setup_logging()
             result = main.menu_principal(1, "User")
 
         self.assertFalse(result)
@@ -34,6 +35,7 @@ class TestMenuPrincipalIntegration(unittest.TestCase):
             patch("builtins.input", lambda _: next(inputs)),
             patch("sys.stdout", new_callable=io.StringIO) as fake_out,
         ):
+            main.setup_logging()
             result = main.menu_principal(1, "User")
 
         self.assertFalse(result)
@@ -49,6 +51,7 @@ class TestMenuPrincipalIntegration(unittest.TestCase):
             patch("builtins.input", lambda _: next(inputs)),
             patch("sys.stdout", new_callable=io.StringIO) as fake_out,
         ):
+            main.setup_logging()
             result = main.menu_principal(1, "User")
 
         self.assertFalse(result)


### PR DESCRIPTION
## Summary
- Close existing logging handlers before reconfiguring
- Remove redundant setup_logging call from CLI menu
- Adjust integration tests to configure logging explicitly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9a0d26d70832cb18151a432a6ba75