### PR TITLE
Refactor database connections using context managers

### DIFF
--- a/hermes/data/database.py
+++ b/hermes/data/database.py
@@ -7,62 +7,61 @@ from ..config import config
 # value provided by :mod:`hermes.config`.
 DB_PATH = config.DB_PATH
 
-def conectar():
-    return sqlite3.connect(DB_PATH)
-
 def inicializar_banco():
-    conn = conectar()
-    cursor = conn.cursor()
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.cursor()
 
-    cursor.execute("""
-        CREATE TABLE IF NOT EXISTS usuarios (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            nome TEXT NOT NULL,
-            tipo TEXT NOT NULL,
-            voz_id TEXT
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS usuarios (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                nome TEXT NOT NULL,
+                tipo TEXT NOT NULL,
+                voz_id TEXT
+            )
+            """
         )
-    """)
 
-    cursor.execute("""
-        CREATE TABLE IF NOT EXISTS ideias (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            usuario_id INTEGER NOT NULL,
-            texto TEXT NOT NULL,
-            data TEXT NOT NULL,
-            FOREIGN KEY(usuario_id) REFERENCES usuarios(id)
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ideias (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                usuario_id INTEGER NOT NULL,
+                texto TEXT NOT NULL,
+                data TEXT NOT NULL,
+                FOREIGN KEY(usuario_id) REFERENCES usuarios(id)
+            )
+            """
         )
-    """)
-
-    conn.commit()
-    conn.close()
 
 def criar_usuario(nome, tipo, voz_id=None):
-    conn = conectar()
-    cursor = conn.cursor()
-    cursor.execute("INSERT INTO usuarios (nome, tipo, voz_id) VALUES (?, ?, ?)", (nome, tipo, voz_id))
-    conn.commit()
-    conn.close()
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO usuarios (nome, tipo, voz_id) VALUES (?, ?, ?)",
+            (nome, tipo, voz_id),
+        )
 
 def buscar_usuarios():
-    conn = conectar()
-    cursor = conn.cursor()
-    cursor.execute("SELECT id, nome, tipo FROM usuarios")
-    usuarios = cursor.fetchall()
-    conn.close()
-    return usuarios
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id, nome, tipo FROM usuarios")
+        return cursor.fetchall()
 
 def salvar_ideia(usuario_id, texto):
     data = datetime.now().isoformat()
-    conn = conectar()
-    cursor = conn.cursor()
-    cursor.execute("INSERT INTO ideias (usuario_id, texto, data) VALUES (?, ?, ?)", (usuario_id, texto, data))
-    conn.commit()
-    conn.close()
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO ideias (usuario_id, texto, data) VALUES (?, ?, ?)",
+            (usuario_id, texto, data),
+        )
 
 def listar_ideias(usuario_id):
-    conn = conectar()
-    cursor = conn.cursor()
-    cursor.execute("SELECT texto, data FROM ideias WHERE usuario_id = ? ORDER BY data DESC", (usuario_id,))
-    ideias = cursor.fetchall()
-    conn.close()
-    return ideias
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT texto, data FROM ideias WHERE usuario_id = ? ORDER BY data DESC",
+            (usuario_id,),
+        )
+        return cursor.fetchall()


### PR DESCRIPTION
## Summary
- refactor database module to use `with sqlite3.connect(DB_PATH)` for automatic transaction handling
- remove manual commit and close calls from CRUD functions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9b94cbb48832cb62b577264ab080c