### PR TITLE
feat: add robust int parsing with defaults

### DIFF
--- a/hermes/config.py
+++ b/hermes/config.py
@@ -7,6 +7,7 @@ customised via environment variables or command-line arguments.
 from __future__ import annotations
 
 import argparse
+import logging
 import os
 from dataclasses import dataclass
 from typing import Sequence
@@ -22,13 +23,32 @@ class Config:
     TIMEOUT: int = 30  # seconds
 
 
+logger = logging.getLogger(__name__)
+
+
+def _safe_int(value: str | None, default: int, name: str) -> int:
+    """Safely convert ``value`` to ``int``.
+
+    Logs a warning and returns ``default`` if conversion fails.
+    """
+    try:
+        return int(value) if value is not None else default
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s %r; using %d", name, value, default)
+        return default
+
+
 def _from_env() -> Config:
     """Create a :class:`Config` instance from environment variables."""
     return Config(
         DB_PATH=os.getenv("HERMES_DB_PATH", Config.DB_PATH),
-        API_PORT=int(os.getenv("HERMES_API_PORT", Config.API_PORT)),
+        API_PORT=_safe_int(
+            os.getenv("HERMES_API_PORT"), Config.API_PORT, "HERMES_API_PORT"
+        ),
         OLLAMA_MODEL=os.getenv("HERMES_OLLAMA_MODEL", Config.OLLAMA_MODEL),
-        TIMEOUT=int(os.getenv("HERMES_TIMEOUT", Config.TIMEOUT)),
+        TIMEOUT=_safe_int(
+            os.getenv("HERMES_TIMEOUT"), Config.TIMEOUT, "HERMES_TIMEOUT"
+        ),
     )
 
 
@@ -46,17 +66,17 @@ def load_from_args(args: Sequence[str] | None = None) -> Config:
     """
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--db-path")
-    parser.add_argument("--api-port", type=int)
+    parser.add_argument("--api-port")
     parser.add_argument("--ollama-model")
-    parser.add_argument("--timeout", type=int)
+    parser.add_argument("--timeout")
 
     namespace, _ = parser.parse_known_args(args)
 
     global config
     config = Config(
         DB_PATH=namespace.db_path or config.DB_PATH,
-        API_PORT=namespace.api_port or config.API_PORT,
+        API_PORT=_safe_int(namespace.api_port, config.API_PORT, "--api-port"),
         OLLAMA_MODEL=namespace.ollama_model or config.OLLAMA_MODEL,
-        TIMEOUT=namespace.timeout or config.TIMEOUT,
+        TIMEOUT=_safe_int(namespace.timeout, config.TIMEOUT, "--timeout"),
     )
     return config


### PR DESCRIPTION
## Summary
- handle invalid integer environment variables with warnings and defaults
- safely parse command-line integer options in `load_from_args`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ba854150832cad0f59599bf9930b