### PR TITLE
refactor: structured response handling and logging for LLM service

### DIFF
--- a/hermes/core/registro_ideias.py
+++ b/hermes/core/registro_ideias.py
@@ -29,12 +29,12 @@ Tema: <tema>
 Resumo: <resumo>
 """
 
-    resposta = gerar_resposta(prompt, url=url, model=model)
-    if resposta.startswith("[FALHA]"):
-        raise RuntimeError(resposta)
+    resultado = gerar_resposta(prompt, url=url, model=model)
+    if not resultado.get("ok", False):
+        raise RuntimeError(resultado.get("message", "Erro desconhecido"))
 
     salvar_ideia(usuario_id, f"{titulo}\n\n{descricao}")
-    return resposta
+    return resultado["response"]
 
 
 if __name__ == "__main__":

--- a/testar_llm.py
+++ b/testar_llm.py
@@ -9,4 +9,7 @@ resposta = gerar_resposta(
     model=os.getenv("LLM_MODEL"),
 )
 print("Resposta do modelo:")
-print(resposta)
+if resposta.get("ok"):
+    print(resposta["response"])
+else:
+    print("Falha:", resposta.get("message"))

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -26,7 +26,8 @@ class TestGerarResposta(unittest.TestCase):
         mock_post.return_value = mock_response
 
         result = llm_interface.gerar_resposta("Oi?", url="http://test", model="fake")
-        self.assertEqual(result, "ok")
+        self.assertTrue(result["ok"])  # type: ignore[index]
+        self.assertEqual(result["response"], "ok")
 
     @patch("hermes.services.llm_interface.requests.post")
     def test_falha_conexao(self, mock_post):
@@ -34,7 +35,8 @@ class TestGerarResposta(unittest.TestCase):
             "falha"
         )
         result = llm_interface.gerar_resposta("Oi?", url="http://test", model="fake")
-        self.assertTrue(result.startswith("[FALHA]"))
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error"], "ConnectionError")
 
     @patch("hermes.services.llm_interface.requests.post")
     def test_resposta_inesperada(self, mock_post):
@@ -44,7 +46,8 @@ class TestGerarResposta(unittest.TestCase):
         mock_post.return_value = mock_response
 
         result = llm_interface.gerar_resposta("Oi?", url="http://test", model="fake")
-        self.assertEqual(result, "[ERRO] Sem resposta do modelo")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error"], "missing_response")
 
 
 if __name__ == "__main__":

--- a/tests/test_registro_ideias.py
+++ b/tests/test_registro_ideias.py
@@ -15,7 +15,7 @@ class TestRegistrarIdeiaComLLM(unittest.TestCase):
         with (
             patch(
                 "hermes.core.registro_ideias.gerar_resposta",
-                return_value="Tema: X\nResumo: Y",
+                return_value={"ok": True, "response": "Tema: X\nResumo: Y"},
             ) as mock_llm,
             patch("hermes.core.registro_ideias.salvar_ideia") as mock_salvar,
             patch("builtins.print"),
@@ -42,7 +42,7 @@ class TestRegistrarIdeiaComLLM(unittest.TestCase):
         with (
             patch(
                 "hermes.core.registro_ideias.gerar_resposta",
-                return_value="[FALHA] erro",
+                return_value={"ok": False, "message": "erro"},
             ) as mock_llm,
             patch("hermes.core.registro_ideias.salvar_ideia") as mock_salvar,
             patch("builtins.print"),


### PR DESCRIPTION
## Summary
- log requests and JSON decode errors in LLM interface
- return structured response objects instead of raw strings
- update idea registration flow and tests for new error-handling

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9bb520780832ca6b3f491ed8aba3b