### PR TITLE
refactor: centralize requests test stub

### DIFF
--- a/tests/requests_stub.py
+++ b/tests/requests_stub.py
@@ -1,0 +1,20 @@
+import sys
+import types
+
+# Provide a minimal 'requests' stub if the real library is unavailable.
+if "requests" not in sys.modules:
+    requests_stub = types.ModuleType("requests")
+
+    class RequestException(Exception):
+        """Base exception matching requests.RequestException."""
+
+    class ConnectionError(RequestException):
+        """Simple stand-in for requests.ConnectionError."""
+
+    requests_stub.exceptions = types.SimpleNamespace(
+        RequestException=RequestException, ConnectionError=ConnectionError
+    )
+    requests_stub.post = lambda *a, **k: None
+    sys.modules["requests"] = requests_stub
+
+__all__ = ["requests_stub"]

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -1,18 +1,7 @@
-import sys
-import types
 import unittest
 from unittest.mock import Mock, patch
 
-# Provide a minimal 'requests' stub if the real library is unavailable.
-if "requests" not in sys.modules:
-    requests_stub = types.ModuleType("requests")
-
-    class ConnError(Exception):
-        pass
-
-    requests_stub.exceptions = types.SimpleNamespace(ConnectionError=ConnError)
-    requests_stub.post = lambda *a, **k: None
-    sys.modules["requests"] = requests_stub
+import tests.requests_stub  # noqa: F401
 
 from hermes.services import llm_interface
 

--- a/tests/test_llm_script.py
+++ b/tests/test_llm_script.py
@@ -1,15 +1,7 @@
-import sys
-import types
 import unittest
 from unittest.mock import Mock, patch
 
-if "requests" not in sys.modules:
-    requests_stub = types.ModuleType("requests")
-    class ConnError(Exception):
-        pass
-    requests_stub.exceptions = types.SimpleNamespace(ConnectionError=ConnError)
-    requests_stub.post = lambda *a, **k: None
-    sys.modules["requests"] = requests_stub
+import tests.requests_stub  # noqa: F401
 
 from hermes.services.llm_interface import gerar_resposta
 


### PR DESCRIPTION
## Summary
- replace duplicated requests stubs with shared helper
- update llm interface and script tests to use shared stub

## Testing
- `pytest tests/test_llm_interface.py tests/test_llm_script.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9d3043140832c9cce5eae22c41d45