### PR TITLE
Expand idea schema and update helpers

### DIFF
--- a/hermes/core/registro_ideias.py
+++ b/hermes/core/registro_ideias.py
@@ -33,8 +33,24 @@ Resumo: <resumo>
     if not resultado.get("ok", False):
         raise RuntimeError(resultado.get("message", "Erro desconhecido"))
 
-    salvar_ideia(usuario_id, f"{titulo}\n\n{descricao}")
-    return resultado["response"]
+    resposta = resultado["response"]
+    tema = None
+    resumo = None
+    for linha in resposta.splitlines():
+        if linha.lower().startswith("tema:"):
+            tema = linha.split(":", 1)[1].strip()
+        elif linha.lower().startswith("resumo:"):
+            resumo = linha.split(":", 1)[1].strip()
+
+    salvar_ideia(
+        usuario_id,
+        titulo,
+        descricao,
+        source=url,
+        llm_summary=resumo,
+        llm_topic=tema,
+    )
+    return resposta
 
 
 if __name__ == "__main__":

--- a/hermes/data/database.py
+++ b/hermes/data/database.py
@@ -1,5 +1,4 @@
 import sqlite3
-from datetime import datetime
 
 from ..config import config
 
@@ -26,10 +25,15 @@ def inicializar_banco():
             """
             CREATE TABLE IF NOT EXISTS ideias (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                usuario_id INTEGER NOT NULL,
-                texto TEXT NOT NULL,
-                data TEXT NOT NULL,
-                FOREIGN KEY(usuario_id) REFERENCES usuarios(id)
+                user_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                body TEXT NOT NULL,
+                source TEXT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                llm_summary TEXT,
+                llm_topic TEXT,
+                tags TEXT,
+                FOREIGN KEY(user_id) REFERENCES usuarios(id)
             )
             """
         )
@@ -48,20 +52,42 @@ def buscar_usuarios():
         cursor.execute("SELECT id, nome, tipo FROM usuarios")
         return cursor.fetchall()
 
-def salvar_ideia(usuario_id, texto):
-    data = datetime.now().isoformat()
+def salvar_ideia(
+    user_id,
+    title,
+    body,
+    source=None,
+    llm_summary=None,
+    llm_topic=None,
+    tags=None,
+):
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "INSERT INTO ideias (usuario_id, texto, data) VALUES (?, ?, ?)",
-            (usuario_id, texto, data),
+            """
+            INSERT INTO ideias (
+                user_id,
+                title,
+                body,
+                source,
+                llm_summary,
+                llm_topic,
+                tags
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (user_id, title, body, source, llm_summary, llm_topic, tags),
         )
 
-def listar_ideias(usuario_id):
+def listar_ideias(user_id):
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT texto, data FROM ideias WHERE usuario_id = ? ORDER BY data DESC",
-            (usuario_id,),
+            """
+            SELECT title, body, created_at
+            FROM ideias
+            WHERE user_id = ?
+            ORDER BY created_at DESC
+            """,
+            (user_id,),
         )
         return cursor.fetchall()

--- a/hermes/ui/cli.py
+++ b/hermes/ui/cli.py
@@ -62,7 +62,7 @@ def menu_principal(usuario_id, nome_usuario):
                     input("Deseja salvar a ideia mesmo assim? (s/N): ").strip().lower()
                     == "s"
                 ):
-                    salvar_ideia(usuario_id, f"{titulo}\n\n{descricao}")
+                    salvar_ideia(usuario_id, titulo, descricao)
                     logger.info("✅ Ideia registrada sem sugestões.")
                 else:
                     logger.info("❌ Ideia não registrada.")
@@ -70,8 +70,8 @@ def menu_principal(usuario_id, nome_usuario):
             ideias = listar_ideias(usuario_id)
             if ideias:
                 logger.info("\nMinhas ideias:")
-                for texto, data in ideias:
-                    logger.info("[%s] %s", data, texto)
+                for titulo, corpo, data in ideias:
+                    logger.info("[%s] %s - %s", data, titulo, corpo)
             else:
                 logger.info("Nenhuma ideia registrada.")
         elif opcao == "3":

--- a/hermes/ui/gui.py
+++ b/hermes/ui/gui.py
@@ -108,7 +108,7 @@ class HermesGUI(QWidget):
                 QMessageBox.Yes | QMessageBox.No,
             )
             if opcao == QMessageBox.Yes:
-                salvar_ideia(usuario_id, f"{titulo}\n\n{descricao}")
+                salvar_ideia(usuario_id, titulo, descricao)
                 QMessageBox.information(self, "Sucesso", "Ideia salva sem sugestões.")
             else:
                 return
@@ -123,14 +123,18 @@ class HermesGUI(QWidget):
         if not usuario_id:
             return
         ideias = listar_ideias_db(usuario_id)
-        for texto, data in ideias:
-            item = QListWidgetItem(f"{data[:10]} - {texto.splitlines()[0]}")
-            item.setData(1000, (data, texto))  # Armazena a ideia completa no item
+        for titulo, corpo, data in ideias:
+            item = QListWidgetItem(f"{data[:10]} - {titulo}")
+            item.setData(1000, (data, titulo, corpo))  # Armazena a ideia completa
             self.idea_list.addItem(item)
 
     def exibir_ideia_completa(self, item):
-        data, texto = item.data(1000)
-        QMessageBox.information(self, "Ideia Completa", f"📅 {data}\n\n{texto}")
+        data, titulo, corpo = item.data(1000)
+        QMessageBox.information(
+            self,
+            "Ideia Completa",
+            f"📅 {data}\n\n{titulo}\n\n{corpo}",
+        )
 
     def adicionar_usuario(self):
         nome, ok = QInputDialog.getText(self, "Novo Usuário", "Nome do usuário:")

--- a/tests/test_banco_script.py
+++ b/tests/test_banco_script.py
@@ -30,11 +30,12 @@ class TestarBanco(unittest.TestCase):
 
         usuario_id = next(uid for uid, nome, _ in usuarios if nome == "Pedro")
         texto_ideia = "Criar uma versão web do Hermes acessível pela rede local."
-        database.salvar_ideia(usuario_id, texto_ideia)
+        database.salvar_ideia(usuario_id, "Versao web", texto_ideia)
 
         ideias = database.listar_ideias(usuario_id)
         assert len(ideias) == 1
-        assert ideias[0][0] == texto_ideia
+        assert ideias[0][0] == "Versao web"
+        assert ideias[0][1] == texto_ideia
 
 
 if __name__ == "__main__":

--- a/tests/test_banco_workflow.py
+++ b/tests/test_banco_workflow.py
@@ -32,10 +32,11 @@ class TestBancoWorkflow(unittest.TestCase):
         self.assertIn("Isabella", nomes)
 
         pedro_id = next(u[0] for u in usuarios if u[1] == "Pedro")
-        database.salvar_ideia(pedro_id, "Criar versao web")
+        database.salvar_ideia(pedro_id, "Criar versao web", "Detalhes")
         ideias = database.listar_ideias(pedro_id)
         self.assertEqual(len(ideias), 1)
         self.assertEqual(ideias[0][0], "Criar versao web")
+        self.assertEqual(ideias[0][1], "Detalhes")
 
 
 if __name__ == "__main__":

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -29,10 +29,11 @@ class TestDatabase(unittest.TestCase):
     def test_salvar_e_listar_ideias(self):
         database.criar_usuario("Carol", "Feminino")
         uid = database.buscar_usuarios()[0][0]
-        database.salvar_ideia(uid, "Minha ideia")
+        database.salvar_ideia(uid, "Titulo", "Minha ideia")
         ideias = database.listar_ideias(uid)
         self.assertEqual(len(ideias), 1)
-        texto, data = ideias[0]
+        titulo, texto, data = ideias[0]
+        self.assertEqual(titulo, "Titulo")
         self.assertEqual(texto, "Minha ideia")
         self.assertTrue(data)
 

--- a/tests/test_menu_principal_integration.py
+++ b/tests/test_menu_principal_integration.py
@@ -39,13 +39,13 @@ class TestMenuPrincipalIntegration(unittest.TestCase):
             result = main.menu_principal(1, "User")
 
         self.assertFalse(result)
-        mock_salvar.assert_called_once_with(1, "Titulo\n\nDescricao")
+        mock_salvar.assert_called_once_with(1, "Titulo", "Descricao")
         saida = fake_out.getvalue()
         self.assertIn("Ideia registrada sem sugestões", saida)
 
     def test_listar_ideias_fluxo(self):
         inputs = iter(["2", "4"])
-        ideias = [("Texto", "2024-01-01")]
+        ideias = [("Titulo", "Texto", "2024-01-01")]
         with (
             patch.object(main, "listar_ideias", return_value=ideias),
             patch("builtins.input", lambda _: next(inputs)),
@@ -57,7 +57,7 @@ class TestMenuPrincipalIntegration(unittest.TestCase):
         self.assertFalse(result)
         saida = fake_out.getvalue()
         self.assertIn("Minhas ideias", saida)
-        self.assertIn("[2024-01-01] Texto", saida)
+        self.assertIn("[2024-01-01] Titulo - Texto", saida)
 
 
 if __name__ == "__main__":

--- a/tests/test_registro_ideias.py
+++ b/tests/test_registro_ideias.py
@@ -31,7 +31,14 @@ class TestRegistrarIdeiaComLLM(unittest.TestCase):
         self.assertEqual(mock_llm.call_args.kwargs["url"], url)
         self.assertEqual(mock_llm.call_args.kwargs["model"], model)
 
-        mock_salvar.assert_called_once_with(usuario_id, f"{titulo}\n\n{descricao}")
+        mock_salvar.assert_called_once_with(
+            usuario_id,
+            titulo,
+            descricao,
+            source=url,
+            llm_summary="Y",
+            llm_topic="X",
+        )
         self.assertEqual(resposta, "Tema: X\nResumo: Y")
 
     def test_falha_llm_gera_excecao(self):


### PR DESCRIPTION
## Summary
- enrich `ideias` table with title, body, metadata and automatic timestamp
- adjust database helpers and LLM integration to store new fields
- update CLI/GUI and tests for new idea structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9d65858f8832ca077fd6c571f7971