### PR TITLE
Add database migration utility for schema v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 __pycache__/
 *.pyc
-data/
+/data/
 *.db

--- a/hermes/data/database.py
+++ b/hermes/data/database.py
@@ -1,6 +1,7 @@
 import sqlite3
 
 from ..config import config
+from .migrate import migrate_to_v2
 
 # Allow tests to monkeypatch ``DB_PATH`` directly while defaulting to the
 # value provided by :mod:`hermes.config`.
@@ -37,6 +38,8 @@ def inicializar_banco():
             )
             """
         )
+
+    migrate_to_v2(DB_PATH)
 
 def criar_usuario(nome, tipo, voz_id=None):
     with sqlite3.connect(DB_PATH) as conn:

--- a/hermes/data/migrate.py
+++ b/hermes/data/migrate.py
@@ -1,0 +1,42 @@
+import argparse
+import sqlite3
+from typing import Sequence
+
+from ..config import config
+
+# Columns introduced in schema version 2
+V2_COLUMNS = {
+    "source": "TEXT",
+    "llm_summary": "TEXT",
+    "llm_topic": "TEXT",
+    "tags": "TEXT",
+}
+
+
+def migrate_to_v2(db_path: str) -> None:
+    """Upgrade the database at ``db_path`` to the v2 schema.
+
+    The migration adds any missing columns declared in :data:`V2_COLUMNS` to the
+    ``ideias`` table. It is safe to run multiple times as existing columns are
+    left untouched.
+    """
+    with sqlite3.connect(db_path) as conn:
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(ideias)")
+        existing = {row[1] for row in cursor.fetchall()}
+
+        for column, col_type in V2_COLUMNS.items():
+            if column not in existing:
+                cursor.execute(f"ALTER TABLE ideias ADD COLUMN {column} {col_type}")
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Command-line entry point to run the migration manually."""
+    parser = argparse.ArgumentParser(description="Migrate Hermes DB to v2 schema")
+    parser.add_argument("--db-path", default=config.DB_PATH, help="Path to the SQLite DB")
+    args = parser.parse_args(argv)
+    migrate_to_v2(args.db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "requests",
 ]
 
+[project.scripts]
+"hermes-db-migrate" = "hermes.data.migrate:main"
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["hermes*"]

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,42 @@
+import runpy
+import sqlite3
+import sys
+
+from hermes.data.migrate import migrate_to_v2
+
+
+def create_v1_schema(path: str) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE ideias (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                body TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+
+def test_migrate_adds_columns(tmp_path):
+    db = tmp_path / "test.db"
+    create_v1_schema(str(db))
+    migrate_to_v2(str(db))
+    with sqlite3.connect(str(db)) as conn:
+        cur = conn.execute("PRAGMA table_info(ideias)")
+        cols = {row[1] for row in cur.fetchall()}
+    assert {"source", "llm_summary", "llm_topic", "tags"}.issubset(cols)
+    migrate_to_v2(str(db))  # idempotent
+
+
+def test_migration_cli(tmp_path, monkeypatch):
+    db = tmp_path / "cli.db"
+    create_v1_schema(str(db))
+    monkeypatch.setattr(sys, "argv", ["migrate", "--db-path", str(db)])
+    runpy.run_module("hermes.data.migrate", run_name="__main__")
+    with sqlite3.connect(str(db)) as conn:
+        cur = conn.execute("PRAGMA table_info(ideias)")
+        cols = {row[1] for row in cur.fetchall()}
+    assert {"source", "llm_summary", "llm_topic", "tags"}.issubset(cols)


### PR DESCRIPTION
## Summary
- ensure SQLite schema upgrades via new `migrate_to_v2` utility
- run migration automatically on startup and via new `hermes-db-migrate` script
- cover migration workflow with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9d94eae98832ca8323fb35d311fd5