### PR TITLE
feat: add SQLite DAO for ideas

### DIFF
--- a/hermes/core/registro_ideias.py
+++ b/hermes/core/registro_ideias.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from ..data.database import salvar_ideia
+from ..services.db import add_idea
 from ..services.llm_interface import gerar_resposta
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ Resumo: <resumo>
         elif linha.lower().startswith("resumo:"):
             resumo = linha.split(":", 1)[1].strip()
 
-    salvar_ideia(
+    add_idea(
         usuario_id,
         titulo,
         descricao,

--- a/hermes/services/__init__.py
+++ b/hermes/services/__init__.py
@@ -1,3 +1,5 @@
 """External service integrations for Hermes."""
 
-__all__ = ["llm_interface"]
+from . import db, llm_interface
+
+__all__ = ["llm_interface", "db"]

--- a/hermes/services/db.py
+++ b/hermes/services/db.py
@@ -1,0 +1,159 @@
+"""SQLite-based Data Access Object for Hermes ideas.
+
+This module provides simple helper functions to interact with the
+``ideias`` table using the schema v2.  It mirrors part of the previous
+``hermes.data.database`` API but returns dictionaries instead of tuples
+and exposes CRUD operations for ideas.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Iterable
+
+from ..config import config
+
+DB_PATH = config.DB_PATH
+
+# Columns allowed to be updated via :func:`update_idea`
+IDEIA_COLUMNS = {
+    "user_id",
+    "title",
+    "body",
+    "source",
+    "llm_summary",
+    "llm_topic",
+    "tags",
+}
+
+
+def _dicts(cursor: sqlite3.Cursor, rows: Iterable[sqlite3.Row]) -> list[dict]:
+    """Convert ``sqlite3.Row`` objects to plain dictionaries."""
+
+    return [dict(row) for row in rows]
+
+
+def add_idea(
+    user_id: int,
+    title: str,
+    body: str,
+    source: str | None = None,
+    llm_summary: str | None = None,
+    llm_topic: str | None = None,
+    tags: str | None = None,
+) -> int:
+    """Insert a new idea and return its ``id``."""
+
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO ideias (
+                user_id,
+                title,
+                body,
+                source,
+                llm_summary,
+                llm_topic,
+                tags
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (user_id, title, body, source, llm_summary, llm_topic, tags),
+        )
+        return int(cursor.lastrowid)
+
+
+def update_idea(idea_id: int, **fields: Any) -> None:
+    """Update columns of ``ideias`` for ``idea_id``.
+
+    Only known columns present in ``fields`` are updated. Passing no valid
+    columns results in a no-op.
+    """
+
+    cols = [col for col in fields.keys() if col in IDEIA_COLUMNS]
+    if not cols:
+        return
+
+    assignments = ", ".join(f"{col} = ?" for col in cols)
+    params = [fields[col] for col in cols]
+    params.append(idea_id)
+
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute(f"UPDATE ideias SET {assignments} WHERE id = ?", params)
+
+
+def delete_idea(idea_id: int) -> None:
+    """Remove an idea from the database."""
+
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM ideias WHERE id = ?", (idea_id,))
+
+
+def list_ideas(user_id: int) -> list[dict]:
+    """Return a list of ideas for ``user_id`` ordered by ``created_at`` desc."""
+
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, user_id, title, body, source, created_at, llm_summary,
+                   llm_topic, tags
+            FROM ideias
+            WHERE user_id = ?
+            ORDER BY datetime(created_at) DESC
+            """,
+            (user_id,),
+        )
+        return _dicts(cursor, cursor.fetchall())
+
+
+def search_ideas(
+    user_id: int | None = None,
+    text: str | None = None,
+    topic: str | None = None,
+    tag: str | None = None,
+) -> list[dict]:
+    """Search ideas using simple ``LIKE``/``INSTR`` filters.
+
+    Parameters are optional and combined using ``AND`` when provided. The
+    returned list is ordered by ``created_at`` descending.
+    """
+
+    conditions = []
+    params: list[Any] = []
+
+    if user_id is not None:
+        conditions.append("user_id = ?")
+        params.append(user_id)
+    if text:
+        like = f"%{text}%"
+        conditions.append(
+            "(title LIKE ? OR body LIKE ? OR IFNULL(llm_summary, '') LIKE ?)"
+        )
+        params.extend([like, like, like])
+    if topic:
+        conditions.append("IFNULL(llm_topic, '') LIKE ?")
+        params.append(f"%{topic}%")
+    if tag:
+        # Look for tag inside comma-separated list
+        conditions.append(
+            "INSTR(',' || IFNULL(tags, '') || ',', ',' || ? || ',') > 0"
+        )
+        params.append(tag)
+
+    query = (
+        "SELECT id, user_id, title, body, source, created_at, llm_summary, "
+        "llm_topic, tags FROM ideias"
+    )
+    if conditions:
+        query += " WHERE " + " AND ".join(conditions)
+    query += " ORDER BY datetime(created_at) DESC"
+
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute(query, params)
+        return _dicts(cursor, cursor.fetchall())

--- a/hermes/ui/cli.py
+++ b/hermes/ui/cli.py
@@ -3,14 +3,9 @@ import sys
 
 from ..config import load_from_args
 from ..core.registro_ideias import registrar_ideia_com_llm
-from ..data.database import (
-    buscar_usuarios,
-    criar_usuario,
-    inicializar_banco,
-    listar_ideias,
-    salvar_ideia,
-)
+from ..data.database import buscar_usuarios, criar_usuario, inicializar_banco
 from ..logging import setup_logging
+from ..services.db import add_idea, list_ideas
 
 logger = logging.getLogger(__name__)
 
@@ -62,16 +57,21 @@ def menu_principal(usuario_id, nome_usuario):
                     input("Deseja salvar a ideia mesmo assim? (s/N): ").strip().lower()
                     == "s"
                 ):
-                    salvar_ideia(usuario_id, titulo, descricao)
+                    add_idea(usuario_id, titulo, descricao)
                     logger.info("✅ Ideia registrada sem sugestões.")
                 else:
                     logger.info("❌ Ideia não registrada.")
         elif opcao == "2":
-            ideias = listar_ideias(usuario_id)
+            ideias = list_ideas(usuario_id)
             if ideias:
                 logger.info("\nMinhas ideias:")
-                for titulo, corpo, data in ideias:
-                    logger.info("[%s] %s - %s", data, titulo, corpo)
+                for ideia in ideias:
+                    logger.info(
+                        "[%s] %s - %s",
+                        ideia["created_at"],
+                        ideia["title"],
+                        ideia["body"],
+                    )
             else:
                 logger.info("Nenhuma ideia registrada.")
         elif opcao == "3":

--- a/hermes/ui/gui.py
+++ b/hermes/ui/gui.py
@@ -16,12 +16,8 @@ from PyQt5.QtWidgets import (
 )
 
 from ..core.registro_ideias import registrar_ideia_com_llm
-from ..data.database import (
-    buscar_usuarios,
-    criar_usuario,
-    listar_ideias as listar_ideias_db,
-    salvar_ideia,
-)
+from ..data.database import buscar_usuarios, criar_usuario
+from ..services.db import add_idea, list_ideas
 
 
 class HermesGUI(QWidget):
@@ -108,7 +104,7 @@ class HermesGUI(QWidget):
                 QMessageBox.Yes | QMessageBox.No,
             )
             if opcao == QMessageBox.Yes:
-                salvar_ideia(usuario_id, titulo, descricao)
+                add_idea(usuario_id, titulo, descricao)
                 QMessageBox.information(self, "Sucesso", "Ideia salva sem sugestões.")
             else:
                 return
@@ -122,8 +118,11 @@ class HermesGUI(QWidget):
         self.idea_list.clear()
         if not usuario_id:
             return
-        ideias = listar_ideias_db(usuario_id)
-        for titulo, corpo, data in ideias:
+        ideias = list_ideas(usuario_id)
+        for ideia in ideias:
+            data = ideia["created_at"]
+            titulo = ideia["title"]
+            corpo = ideia["body"]
             item = QListWidgetItem(f"{data[:10]} - {titulo}")
             item.setData(1000, (data, titulo, corpo))  # Armazena a ideia completa
             self.idea_list.addItem(item)

--- a/tests/test_menu_principal_integration.py
+++ b/tests/test_menu_principal_integration.py
@@ -31,7 +31,7 @@ class TestMenuPrincipalIntegration(unittest.TestCase):
             patch.object(
                 main, "registrar_ideia_com_llm", side_effect=RuntimeError("falha")
             ),
-            patch.object(main, "salvar_ideia") as mock_salvar,
+            patch.object(main, "add_idea") as mock_add,
             patch("builtins.input", lambda _: next(inputs)),
             patch("sys.stdout", new_callable=io.StringIO) as fake_out,
         ):
@@ -39,15 +39,15 @@ class TestMenuPrincipalIntegration(unittest.TestCase):
             result = main.menu_principal(1, "User")
 
         self.assertFalse(result)
-        mock_salvar.assert_called_once_with(1, "Titulo", "Descricao")
+        mock_add.assert_called_once_with(1, "Titulo", "Descricao")
         saida = fake_out.getvalue()
         self.assertIn("Ideia registrada sem sugestões", saida)
 
     def test_listar_ideias_fluxo(self):
         inputs = iter(["2", "4"])
-        ideias = [("Titulo", "Texto", "2024-01-01")]
+        ideias = [{"title": "Titulo", "body": "Texto", "created_at": "2024-01-01"}]
         with (
-            patch.object(main, "listar_ideias", return_value=ideias),
+            patch.object(main, "list_ideas", return_value=ideias),
             patch("builtins.input", lambda _: next(inputs)),
             patch("sys.stdout", new_callable=io.StringIO) as fake_out,
         ):

--- a/tests/test_registro_ideias.py
+++ b/tests/test_registro_ideias.py
@@ -17,7 +17,7 @@ class TestRegistrarIdeiaComLLM(unittest.TestCase):
                 "hermes.core.registro_ideias.gerar_resposta",
                 return_value={"ok": True, "response": "Tema: X\nResumo: Y"},
             ) as mock_llm,
-            patch("hermes.core.registro_ideias.salvar_ideia") as mock_salvar,
+            patch("hermes.core.registro_ideias.add_idea") as mock_add,
             patch("builtins.print"),
         ):
             resposta = registrar_ideia_com_llm(
@@ -31,7 +31,7 @@ class TestRegistrarIdeiaComLLM(unittest.TestCase):
         self.assertEqual(mock_llm.call_args.kwargs["url"], url)
         self.assertEqual(mock_llm.call_args.kwargs["model"], model)
 
-        mock_salvar.assert_called_once_with(
+        mock_add.assert_called_once_with(
             usuario_id,
             titulo,
             descricao,
@@ -51,14 +51,14 @@ class TestRegistrarIdeiaComLLM(unittest.TestCase):
                 "hermes.core.registro_ideias.gerar_resposta",
                 return_value={"ok": False, "message": "erro"},
             ) as mock_llm,
-            patch("hermes.core.registro_ideias.salvar_ideia") as mock_salvar,
+            patch("hermes.core.registro_ideias.add_idea") as mock_add,
             patch("builtins.print"),
         ):
             with self.assertRaises(RuntimeError):
                 registrar_ideia_com_llm(usuario_id, titulo, descricao)
 
         mock_llm.assert_called_once()
-        mock_salvar.assert_not_called()
+        mock_add.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement SQLite-based DAO for ideas with CRUD and search helpers
- route core logic and UI through new DAO instead of direct DB module
- expose DAO via services package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9db05dbd4832c9c041b15d9749d5e