### PR TITLE
Add DAO and migration tests

### DIFF
--- a/tests/test_db_dao.py
+++ b/tests/test_db_dao.py
@@ -1,0 +1,87 @@
+import sqlite3
+
+import pytest
+
+from hermes.data import database
+from hermes.data.migrate import migrate_to_v2
+from hermes.services import db as dao
+
+
+@pytest.fixture
+def setup_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "dao.db"
+    monkeypatch.setattr(database, "DB_PATH", str(db_file))
+    monkeypatch.setattr(dao, "DB_PATH", str(db_file))
+    database.inicializar_banco()
+    migrate_to_v2(str(db_file))
+    database.criar_usuario("Alice", "tipo")
+    user_id = database.buscar_usuarios()[0][0]
+    return user_id, str(db_file)
+
+
+def test_add_idea_inserts_row(setup_db):
+    user_id, db_path = setup_db
+    idea_id = dao.add_idea(user_id, "Title", "Body", source="web")
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT id, user_id, title, body, source FROM ideias"
+        ).fetchone()
+    assert row == (idea_id, user_id, "Title", "Body", "web")
+
+
+def test_update_idea_updates_row(setup_db):
+    user_id, db_path = setup_db
+    idea_id = dao.add_idea(user_id, "Old", "Body")
+    dao.update_idea(idea_id, title="New", tags="one,two")
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT title, tags FROM ideias WHERE id = ?", (idea_id,)
+        ).fetchone()
+    assert row == ("New", "one,two")
+
+
+def test_delete_idea_removes_row(setup_db):
+    user_id, db_path = setup_db
+    idea_id = dao.add_idea(user_id, "T", "B")
+    dao.delete_idea(idea_id)
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM ideias").fetchone()[0]
+    assert count == 0
+
+
+def test_list_ideas_orders_by_created_at(setup_db):
+    user_id, db_path = setup_db
+    first = dao.add_idea(user_id, "First", "B1")
+    second = dao.add_idea(user_id, "Second", "B2")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE ideias SET created_at = '2000-01-01T00:00:00' WHERE id = ?",
+            (first,)
+        )
+    ideas = dao.list_ideas(user_id)
+    assert [idea["id"] for idea in ideas] == [second, first]
+
+
+def test_search_ideas_filters(setup_db):
+    user_id, db_path = setup_db
+    first = dao.add_idea(
+        user_id, "AI Title", "about AI", llm_topic="ai", tags="tech,ai"
+    )
+    second = dao.add_idea(
+        user_id, "Music", "about music", llm_topic="music", tags="art"
+    )
+    database.criar_usuario("Bob", "tipo")
+    other_user = database.buscar_usuarios()[1][0]
+    third = dao.add_idea(other_user, "Other", "body", llm_topic="ai", tags="tech")
+
+    res = dao.search_ideas(text="AI")
+    assert [r["id"] for r in res] == [first]
+
+    res = dao.search_ideas(topic="music")
+    assert [r["id"] for r in res] == [second]
+
+    res = dao.search_ideas(tag="tech")
+    assert {r["id"] for r in res} == {first, third}
+
+    res = dao.search_ideas(user_id=user_id)
+    assert {r["id"] for r in res} == {first, second}

--- a/tests/test_migration_v2.py
+++ b/tests/test_migration_v2.py
@@ -1,0 +1,32 @@
+import sqlite3
+
+from hermes.data.migrate import migrate_to_v2
+
+
+def test_migrate_to_v2_preserves_rows_and_adds_columns(tmp_path):
+    db_file = tmp_path / "legacy.db"
+    with sqlite3.connect(db_file) as conn:
+        conn.execute(
+            """
+            CREATE TABLE ideias (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                usuario_id INTEGER NOT NULL,
+                texto TEXT NOT NULL,
+                data TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO ideias (usuario_id, texto, data) VALUES (?, ?, ?)",
+            (1, "old", "2023-01-01")
+        )
+    migrate_to_v2(str(db_file))
+    with sqlite3.connect(db_file) as conn:
+        cur = conn.execute(
+            "SELECT usuario_id, texto, data, source, llm_summary, llm_topic, tags FROM ideias"
+        )
+        rows = cur.fetchall()
+        assert rows == [(1, "old", "2023-01-01", None, None, None, None)]
+        cur = conn.execute("PRAGMA table_info(ideias)")
+        cols = {row[1] for row in cur.fetchall()}
+    assert {"usuario_id", "texto", "data", "source", "llm_summary", "llm_topic", "tags"}.issubset(cols)


### PR DESCRIPTION
## Summary
- add DAO tests verifying idea insertion, updates, deletions, listing, and search behavior
- add migration test ensuring old-schema databases retain data and gain new columns

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9dc0f6f68832c8df9b34446dd7a6e