### PR TITLE
Use DAO for CLI and capture LLM tags

### DIFF
--- a/hermes/core/registro_ideias.py
+++ b/hermes/core/registro_ideias.py
@@ -24,9 +24,11 @@ Descrição: {descricao}
 
 1. Classifique um tema geral (ex: produtividade, tecnologia, pessoal).
 2. Sugira uma versão mais clara e resumida da descrição.
+3. Indique tags relacionadas separadas por vírgula.
 Responda no formato:
 Tema: <tema>
 Resumo: <resumo>
+Tags: <tag1, tag2>
 """
 
     resultado = gerar_resposta(prompt, url=url, model=model)
@@ -36,11 +38,14 @@ Resumo: <resumo>
     resposta = resultado["response"]
     tema = None
     resumo = None
+    tags = None
     for linha in resposta.splitlines():
         if linha.lower().startswith("tema:"):
             tema = linha.split(":", 1)[1].strip()
         elif linha.lower().startswith("resumo:"):
             resumo = linha.split(":", 1)[1].strip()
+        elif linha.lower().startswith("tags:"):
+            tags = linha.split(":", 1)[1].strip()
 
     add_idea(
         usuario_id,
@@ -49,6 +54,7 @@ Resumo: <resumo>
         source=url,
         llm_summary=resumo,
         llm_topic=tema,
+        tags=tags,
     )
     return resposta
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,9 +15,10 @@ class TestCLI(unittest.TestCase):
     def test_main_exits_cleanly(self):
         inputs = iter(["1", "4"])
         with (
-            patch("hermes.data.database.inicializar_banco"),
+            patch("hermes.services.db.init_db"),
             patch(
-                "hermes.data.database.buscar_usuarios", return_value=[(1, "User", "M")]
+                "hermes.services.db.list_users",
+                return_value=[{"id": 1, "name": "User", "kind": "M"}],
             ),
             patch("builtins.input", lambda _: next(inputs)),
         ):

--- a/tests/test_registro_ideias.py
+++ b/tests/test_registro_ideias.py
@@ -15,7 +15,10 @@ class TestRegistrarIdeiaComLLM(unittest.TestCase):
         with (
             patch(
                 "hermes.core.registro_ideias.gerar_resposta",
-                return_value={"ok": True, "response": "Tema: X\nResumo: Y"},
+                return_value={
+                    "ok": True,
+                    "response": "Tema: X\nResumo: Y\nTags: a,b",
+                },
             ) as mock_llm,
             patch("hermes.core.registro_ideias.add_idea") as mock_add,
             patch("builtins.print"),
@@ -38,8 +41,9 @@ class TestRegistrarIdeiaComLLM(unittest.TestCase):
             source=url,
             llm_summary="Y",
             llm_topic="X",
+            tags="a,b",
         )
-        self.assertEqual(resposta, "Tema: X\nResumo: Y")
+        self.assertEqual(resposta, "Tema: X\nResumo: Y\nTags: a,b")
 
     def test_falha_llm_gera_excecao(self):
         usuario_id = 1


### PR DESCRIPTION
## Summary
- Store model-generated topic, summary, and tags when registering ideas
- Add DAO helpers for user management and database initialization
- Switch CLI to new DAO layer and update tests

## Testing
- `pytest -q`
- ⚠️ `pre-commit run --files hermes/services/db.py hermes/core/registro_ideias.py hermes/ui/cli.py tests/test_registro_ideias.py tests/test_cli.py` *(missing dependency: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dcd4942c832c8b5ccba32cb67418