### PR TITLE
feat: add configurable retry for LLM interface

### DIFF
--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -1,43 +1,92 @@
+import json
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
+import requests
 import tests.requests_stub  # noqa: F401
 
 from hermes.services import llm_interface
 
 
-class TestGerarResposta(unittest.TestCase):
-    @patch("hermes.services.llm_interface.requests.post")
-    def test_resposta_sucesso(self, mock_post):
-        mock_response = Mock()
-        mock_response.json.return_value = {"response": "ok"}
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+def _make_response(payload: dict) -> requests.Response:
+    response = requests.Response()
+    response.status_code = 200
+    response._content = json.dumps(payload).encode()
+    return response
 
-        result = llm_interface.gerar_resposta("Oi?", url="http://test", model="fake")
+
+class TestGerarResposta(unittest.TestCase):
+    @patch("requests.adapters.HTTPAdapter.send")
+    def test_resposta_sucesso(self, mock_send):
+        mock_send.return_value = _make_response({"response": "ok"})
+
+        with patch.object(llm_interface.config, "MAX_RETRIES", 1), patch.object(
+            llm_interface.config, "BACKOFF_FACTOR", 0
+        ):
+            result = llm_interface.gerar_resposta(
+                "Oi?", url="http://test", model="fake"
+            )
         self.assertTrue(result["ok"])  # type: ignore[index]
         self.assertEqual(result["response"], "ok")
 
-    @patch("hermes.services.llm_interface.requests.post")
-    def test_falha_conexao(self, mock_post):
-        mock_post.side_effect = llm_interface.requests.exceptions.ConnectionError(
-            "falha"
-        )
-        result = llm_interface.gerar_resposta("Oi?", url="http://test", model="fake")
+    @patch("requests.adapters.HTTPAdapter.send")
+    def test_falha_conexao(self, mock_send):
+        mock_send.side_effect = requests.exceptions.ConnectionError("falha")
+
+        with patch.object(llm_interface.config, "MAX_RETRIES", 1), patch.object(
+            llm_interface.config, "BACKOFF_FACTOR", 0
+        ):
+            result = llm_interface.gerar_resposta(
+                "Oi?", url="http://test", model="fake"
+            )
         self.assertFalse(result["ok"])
         self.assertEqual(result["error"], "ConnectionError")
+        self.assertEqual(result["message"], "Servidor LLM offline")
 
-    @patch("hermes.services.llm_interface.requests.post")
-    def test_resposta_inesperada(self, mock_post):
-        mock_response = Mock()
-        mock_response.json.return_value = {"foo": "bar"}
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+    @patch("requests.adapters.HTTPAdapter.send")
+    def test_timeout(self, mock_send):
+        mock_send.side_effect = requests.exceptions.Timeout("timeout")
 
-        result = llm_interface.gerar_resposta("Oi?", url="http://test", model="fake")
+        with patch.object(llm_interface.config, "MAX_RETRIES", 1), patch.object(
+            llm_interface.config, "BACKOFF_FACTOR", 0
+        ):
+            result = llm_interface.gerar_resposta(
+                "Oi?", url="http://test", model="fake"
+            )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error"], "Timeout")
+        self.assertEqual(result["message"], "Servidor LLM não respondeu a tempo")
+
+    @patch("requests.adapters.HTTPAdapter.send")
+    def test_resposta_inesperada(self, mock_send):
+        mock_send.return_value = _make_response({"foo": "bar"})
+
+        with patch.object(llm_interface.config, "MAX_RETRIES", 1), patch.object(
+            llm_interface.config, "BACKOFF_FACTOR", 0
+        ):
+            result = llm_interface.gerar_resposta(
+                "Oi?", url="http://test", model="fake"
+            )
         self.assertFalse(result["ok"])
         self.assertEqual(result["error"], "missing_response")
+
+    @patch("requests.Session.post")
+    @patch("requests.Session.mount")
+    def test_retry(self, mock_mount, mock_post):
+        mock_post.return_value = _make_response({"response": "ok"})
+
+        with patch.object(llm_interface.config, "MAX_RETRIES", 7), patch.object(
+            llm_interface.config, "BACKOFF_FACTOR", 0.3
+        ):
+            result = llm_interface.gerar_resposta(
+                "Oi?", url="http://test", model="fake"
+            )
+        self.assertTrue(result["ok"])  # type: ignore[index]
+        adapter = mock_mount.call_args[0][1]
+        self.assertEqual(adapter.max_retries.total, 7)
+        self.assertEqual(adapter.max_retries.backoff_factor, 0.3)
 
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/test_llm_script.py
+++ b/tests/test_llm_script.py
@@ -1,29 +1,31 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
+import requests
 import tests.requests_stub  # noqa: F401
 
 from hermes.services.llm_interface import gerar_resposta
+from tests.test_llm_interface import _make_response
 
 
 class TestarLLM(unittest.TestCase):
-    @patch("hermes.services.llm_interface.requests.post")
-    def test_gerar_resposta(self, mock_post):
-        mock_resp = Mock()
-        mock_resp.json.return_value = {
-            "response": "IA é a simulação de inteligência humana por máquinas."
-        }
-        mock_resp.raise_for_status.return_value = None
-        mock_post.return_value = mock_resp
+    @patch("requests.adapters.HTTPAdapter.send")
+    def test_gerar_resposta(self, mock_send):
+        mock_send.return_value = _make_response(
+            {"response": "IA é a simulação de inteligência humana por máquinas."}
+        )
 
         resultado = gerar_resposta(
             "Explique brevemente o que é inteligência artificial.",
-            url="http://fake", model="fake"
+            url="http://fake", model="fake",
         )
         assert resultado["ok"] is True
-        assert resultado["response"] == \
-            "IA é a simulação de inteligência humana por máquinas."
+        assert (
+            resultado["response"]
+            == "IA é a simulação de inteligência humana por máquinas."
+        )
 
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- add `MAX_RETRIES` and `BACKOFF_FACTOR` options to config and CLI
- use `requests.Session` with `Retry` in LLM interface
- handle timeout/offline errors and update tests

## Testing
- `pytest tests/test_llm_interface.py -q`
- `pytest -q`
- `pre-commit run --files hermes/config.py hermes/services/llm_interface.py tests/test_llm_interface.py tests/test_llm_script.py` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68c084fb11a8832c829f95efa08e24b8