### PR TITLE
Ler prompt de arquivo externo

### DIFF
--- a/prompts/resumo_classificar.md
+++ b/prompts/resumo_classificar.md
@@ -1,0 +1,11 @@
+Analise a seguinte ideia:
+Título: {titulo}
+Descrição: {descricao}
+
+1. Classifique um tema geral (ex: produtividade, tecnologia, pessoal).
+2. Sugira uma versão mais clara e resumida da descrição.
+3. Indique tags relacionadas separadas por vírgula.
+Responda no formato:
+Tema: <tema>
+Resumo: <resumo>
+Tags: <tag1, tag2>


### PR DESCRIPTION
## Summary
- Adiciona diretório `prompts` com template `resumo_classificar.md`
- Lê o prompt dinamicamente em `registro_ideias` permitindo alteração sem mudar o código
- Testa que mudanças no arquivo de prompt alteram o texto enviado ao LLM

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c08688c9f4832c86efe998cf17f850