### PR TITLE
Add local FastAPI API for ideas and LLM responses

### DIFF
--- a/hermes/__init__.py
+++ b/hermes/__init__.py
@@ -2,5 +2,5 @@
 
 from . import config
 
-__all__ = ["core", "ui", "services", "data", "config"]
+__all__ = ["core", "ui", "services", "data", "config", "api"]
 __version__ = "0.1.0"

--- a/hermes/api.py
+++ b/hermes/api.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+import time
+from fastapi import FastAPI, HTTPException, Request, Depends, Header
+from pydantic import BaseModel
+
+from .services.db import add_idea, init_db
+from .services.llm_interface import gerar_resposta
+
+
+app = FastAPI()
+
+# --- Auth -----------------------------------------------------------------
+
+def verify_token(x_token: str = Header(...)) -> None:
+    expected = os.getenv("HERMES_TOKEN")
+    if not expected or x_token != expected:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+
+# --- Rate limiting --------------------------------------------------------
+
+REQUEST_LIMIT = 60  # requests per minute
+_window = 60
+_requests: dict[str, tuple[int, float]] = {}
+
+
+@app.middleware("http")
+async def rate_limiter(request: Request, call_next):
+    key = request.client.host or "global"
+    now = time.time()
+    count, start = _requests.get(key, (0, now))
+    if now - start > _window:
+        count, start = 0, now
+    if count >= REQUEST_LIMIT:
+        raise HTTPException(status_code=429, detail="Rate limit exceeded")
+    _requests[key] = (count + 1, start)
+    return await call_next(request)
+
+
+# --- Models ----------------------------------------------------------------
+
+class Idea(BaseModel):
+    user: int
+    title: str
+    body: str
+
+
+class Prompt(BaseModel):
+    prompt: str
+
+
+# --- Startup ---------------------------------------------------------------
+
+@app.on_event("startup")
+def _startup() -> None:
+    init_db()
+
+
+# --- Endpoints -------------------------------------------------------------
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/ideas")
+def create_idea(
+    idea: Idea,
+    request: Request,
+    _: None = Depends(verify_token),
+) -> dict[str, int | str]:
+    device_id = request.headers.get("X-Device-Id", "")
+    source = f"caduceu_{device_id}" if device_id else "caduceu_"
+    idea_id = add_idea(idea.user, idea.title, idea.body, source=source)
+    return {"id": idea_id, "source": source}
+
+
+@app.post("/ask")
+def ask(prompt: Prompt, _: None = Depends(verify_token)) -> dict[str, str]:
+    result = gerar_resposta(prompt.prompt)
+    if not result.get("ok"):
+        raise HTTPException(status_code=502, detail=result.get("message", "error"))
+    return {"response": result["response"]}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8000")))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 PyQt5==5.15.9
 requests
+fastapi
+"pydantic>=1,<3"
 
 # Optional dependencies for future features (not required for basic usage):
 # vosk==0.3.45    # speech recognition

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,54 @@
+import sqlite3
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def api_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_TOKEN", "secret")
+    db_file = tmp_path / "api.db"
+
+    from hermes.services import db as dao
+
+    monkeypatch.setattr(dao, "DB_PATH", str(db_file))
+
+    from hermes import api as api_module
+
+    with TestClient(api_module.app) as client:
+        yield client, api_module, str(db_file)
+
+
+def test_health(api_client):
+    client, _, _ = api_client
+    res = client.get("/health")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+
+
+def test_create_idea_sources_device(api_client):
+    client, _, db_path = api_client
+    res = client.post(
+        "/ideas",
+        json={"user": 1, "title": "T", "body": "B"},
+        headers={"X-Token": "secret", "X-Device-Id": "dev1"},
+    )
+    assert res.status_code == 200
+    assert res.json()["source"] == "caduceu_dev1"
+    with sqlite3.connect(db_path) as conn:
+        source = conn.execute("SELECT source FROM ideias").fetchone()[0]
+    assert source == "caduceu_dev1"
+
+
+def test_ask_returns_response(api_client, monkeypatch):
+    client, api_module, _ = api_client
+
+    def fake(prompt):
+        return {"ok": True, "response": "hi"}
+
+    monkeypatch.setattr(api_module, "gerar_resposta", fake)
+    res = client.post(
+        "/ask", json={"prompt": "hello"}, headers={"X-Token": "secret"}
+    )
+    assert res.status_code == 200
+    assert res.json() == {"response": "hi"}


### PR DESCRIPTION
## Summary
- add FastAPI application with /ideas, /ask and /health endpoints
- support token auth, rate limiting and Caduceus source tagging
- document FastAPI dependencies

## Testing
- `pytest tests/test_api.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c08814a49c832c811d6aadbf50b924