### PR TITLE
Add Caduceu client with offline TTS support

### DIFF
--- a/clients/caduceu/README.md
+++ b/clients/caduceu/README.md
@@ -1,0 +1,34 @@
+# Caduceu Client
+
+This client interacts with a Hermes server for recording ideas and asking
+questions. It loads configuration from `config.yaml` and uses a push-to-talk
+style workflow.
+
+## Configuration
+
+Edit `config.yaml` to match your environment:
+
+```yaml
+server: "http://localhost:8000"  # Base URL of the Hermes server
+token: "replace-with-secret-token"  # API token for authentication
+device_id: "cozinha"  # Identifier for this client device
+```
+
+## Usage
+
+Run the client directly:
+
+```bash
+python clients/caduceu/client.py
+```
+
+Press **Enter** to trigger the push-to-talk prompt, then type your idea.
+The client sends a `POST /ideas` request with JSON data `{user, title, body}`
+and headers `X-Token` and `X-Device-Id`.
+
+The server response is expected to include a `source` field like
+`caduceu_<device_id>`, for example `caduceu_cozinha`.
+
+After submitting an idea you may optionally enter a prompt to
+`POST /ask`. The response is spoken aloud using the offline
+[`pyttsx3`](https://pyttsx3.readthedocs.io/) text‑to‑speech engine.

--- a/clients/caduceu/client.py
+++ b/clients/caduceu/client.py
@@ -1,0 +1,73 @@
+import json
+from pathlib import Path
+
+import pyttsx3
+import requests
+import yaml
+
+CONFIG_PATH = Path(__file__).with_name("config.yaml")
+
+
+def load_config():
+    """Load configuration values from config.yaml."""
+    with CONFIG_PATH.open() as fh:
+        return yaml.safe_load(fh)
+
+
+def push_to_talk():
+    """Simple push-to-talk simulation using console input."""
+    input("Press Enter and start typing your idea (Ctrl+C to quit)...\n")
+    return input("Idea: ")
+
+
+def send_idea(cfg, text):
+    server = cfg["server"].rstrip("/")
+    headers = {
+        "X-Token": cfg["token"],
+        "X-Device-Id": cfg["device_id"],
+    }
+    payload = {"user": cfg["device_id"], "title": text[:30], "body": text}
+    resp = requests.post(f"{server}/ideas", json=payload, headers=headers, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    expected_source = f"caduceu_{cfg['device_id']}"
+    if data.get("source") != expected_source:
+        raise ValueError(f"Unexpected source {data.get('source')}")
+    return data
+
+
+def ask_and_speak(cfg):
+    server = cfg["server"].rstrip("/")
+    headers = {
+        "X-Token": cfg["token"],
+        "X-Device-Id": cfg["device_id"],
+    }
+    prompt = input("Prompt to ask the server (leave empty to skip): ")
+    if not prompt:
+        return
+    resp = requests.post(f"{server}/ask", json={"prompt": prompt}, headers=headers, timeout=30)
+    resp.raise_for_status()
+    answer = resp.json().get("response", "")
+    if not answer:
+        return
+    engine = pyttsx3.init()
+    engine.say(answer)
+    engine.runAndWait()
+
+
+def main():
+    cfg = load_config()
+    while True:
+        try:
+            text = push_to_talk()
+            if not text.strip():
+                continue
+            send_idea(cfg, text)
+            ask_and_speak(cfg)
+        except KeyboardInterrupt:
+            print("\nExiting.")
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/caduceu/config.yaml
+++ b/clients/caduceu/config.yaml
@@ -1,0 +1,11 @@
+# Base URL of the Hermes server
+server: "http://localhost:8000"
+
+# Authentication token for API requests
+# Obtain this token from your Hermes server instance
+token: "replace-with-secret-token"
+
+# Identifier for this client device
+# Used by the server to mark message provenance
+# Example: 'cozinha' or 'sala'
+device_id: "cozinha"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ PyQt5==5.15.9
 requests
 fastapi
 "pydantic>=1,<3"
+pyttsx3
 
 # Optional dependencies for future features (not required for basic usage):
 # vosk==0.3.45    # speech recognition


### PR DESCRIPTION
## Summary
- add configuration template for Caduceu client
- implement Caduceu client with push-to-talk and optional TTS
- document client usage and update dependencies

## Testing
- `python -m py_compile clients/caduceu/client.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests fastapi "pydantic>=1,<3" pyttsx3` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_68c161b6f834832c95d15c0f8796d2d1