### PR TITLE
feat(cli): add semantic search option

### DIFF
--- a/hermes/ui/cli.py
+++ b/hermes/ui/cli.py
@@ -5,6 +5,7 @@ from ..config import load_from_args
 from ..core.registro_ideias import registrar_ideia_com_llm
 from ..logging import setup_logging
 from ..services.db import add_idea, add_user, init_db, list_ideas, list_users
+from ..services import semantic_search
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +39,9 @@ def menu_principal(usuario_id, nome_usuario):
         logger.info("\n=== Hermes (Usuário: %s) ===", nome_usuario)
         logger.info("1. Registrar nova ideia")
         logger.info("2. Listar minhas ideias")
-        logger.info("3. Trocar de usuário")
-        logger.info("4. Sair")
+        logger.info("3. Pesquisar ideias")
+        logger.info("4. Trocar de usuário")
+        logger.info("5. Sair")
         opcao = input("Escolha uma opção: ")
 
         if opcao == "1":
@@ -74,8 +76,22 @@ def menu_principal(usuario_id, nome_usuario):
             else:
                 logger.info("Nenhuma ideia registrada.")
         elif opcao == "3":
-            return True  # trocar de usuário
+            termo = input("Texto de busca: ")
+            resultados = semantic_search(termo, user_id=usuario_id)
+            if resultados:
+                logger.info("\nResultados da busca:")
+                for ideia in resultados:
+                    logger.info(
+                        "[%s] %s - %s",
+                        ideia["created_at"],
+                        ideia["title"],
+                        ideia["body"],
+                    )
+            else:
+                logger.info("Nenhuma ideia encontrada.")
         elif opcao == "4":
+            return True  # trocar de usuário
+        elif opcao == "5":
             logger.info("Encerrando Hermes.")
             return False
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,12 +8,12 @@ from hermes.ui import cli
 
 class TestCLI(unittest.TestCase):
     def test_menu_principal_quit_returns_false(self):
-        with patch("builtins.input", side_effect=["4"]):
+        with patch("builtins.input", side_effect=["5"]):
             result = cli.menu_principal(1, "User")
         self.assertFalse(result)
 
     def test_main_exits_cleanly(self):
-        inputs = iter(["1", "4"])
+        inputs = iter(["1", "5"])
         with (
             patch("hermes.services.db.init_db"),
             patch(


### PR DESCRIPTION
## Summary
- add "Pesquisar ideias" option to CLI main menu
- support semantic idea search and display results
- update CLI tests for new menu options

## Testing
- `pytest tests/test_cli.py tests/test_menu_principal_integration.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests fastapi scikit-learn` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_68c17d98d1d4832cbfbb55441f1a0647