### PR TITLE
Add scikit-learn requirement and document semantic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Caso deseje instalar apenas as dependências listadas, utilize `requirements.txt
 pip install -r requirements.txt
 ```
 
+O arquivo de requisitos inclui o pacote `scikit-learn` (>=1.1),
+necessário para a funcionalidade de busca semântica de ideias.
+
 ### Dependências opcionais
 
 Algumas funcionalidades podem requerer bibliotecas adicionais que não
@@ -85,6 +88,21 @@ python -m hermes
 Na interface, os campos de título e descrição possuem um botão de microfone
 ("🎙️") que permite ditar texto. Ao salvar uma ideia com sucesso, o Hermes
 fornece um breve feedback em voz dizendo "ideia salva".
+
+### Pesquisa semântica
+A aplicação oferece uma pesquisa de ideias baseada em similaridade
+semântica. Após instalar as dependências, importe e utilize a função
+`semantic_search`:
+
+```python
+from hermes.services.semantic_search import semantic_search
+
+resultados = semantic_search("kanban", user_id=1)
+for ideia in resultados:
+    print(ideia["title"])
+```
+
+No modo CLI, selecione a opção **Pesquisar ideias** e informe o termo desejado.
 
 ## Testes
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests
 fastapi
 "pydantic>=1,<3"
 pyttsx3
-scikit-learn
+scikit-learn>=1.1
 vosk==0.3.45  # speech recognition
 
 # Optional dependencies for future features (not required for basic usage):


### PR DESCRIPTION
## Summary
- require scikit-learn>=1.1 to support semantic search
- document semantic search usage and dependency in README

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r /tmp/req.txt` *(fails: Could not find a version that satisfies the requirement PyQt5==5.15.9)*

------
https://chatgpt.com/codex/tasks/task_e_68c18075b478832cabaa1699a24f7540