### PR TITLE
refactor: pluggable vector index for semantic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ for ideia in resultados:
 
 No modo CLI, selecione a opção **Pesquisar ideias** e informe o termo desejado.
 
+O mecanismo utiliza por padrão um índice simples baseado em TF-IDF.  Para
+substituí-lo por soluções mais avançadas como `FAISS` ou `Chroma`, implemente a
+interface ``VectorIndex`` e forneça a instância ao chamar ``semantic_search``:
+
+```python
+from hermes.services.semantic_search import semantic_search, VectorIndex
+
+class MeuIndice(VectorIndex):
+    ...  # implemente fit() e search()
+
+resultado = semantic_search("kanban", index=MeuIndice())
+```
+
 ## Testes
 
 Os testes automatizados utilizam o módulo `unittest` padrão do Python.


### PR DESCRIPTION
## Summary
- introduce `VectorIndex` protocol and default `TfidfVectorIndex`
- allow `semantic_search` to accept custom vector index backends
- document extending semantic search with FAISS or Chroma

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install requests fastapi -q` *(fails: Could not find a version that satisfies the requirement requests)*
- `pytest tests/test_semantic_search.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1816ab6d0832c84577f1dc0ab5f77