### PR TITLE
Add APScheduler-based reminder service

### DIFF
--- a/hermes/__main__.py
+++ b/hermes/__main__.py
@@ -3,12 +3,14 @@
 from .config import load_from_args
 from .logging import setup_logging
 from .ui import gui
+from .services.reminders import start_scheduler
 
 
 def main(argv: list[str] | None = None) -> None:
     """Launch the graphical user interface."""
     setup_logging()
     load_from_args(argv)
+    start_scheduler()
     gui.main()
 
 

--- a/hermes/api.py
+++ b/hermes/api.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from .services.db import add_idea, init_db
 from .services.llm_interface import gerar_resposta
+from .services.reminders import start_scheduler
 
 
 app = FastAPI()
@@ -56,6 +57,7 @@ class Prompt(BaseModel):
 @app.on_event("startup")
 def _startup() -> None:
     init_db()
+    start_scheduler()
 
 
 # --- Endpoints -------------------------------------------------------------

--- a/hermes/services/__init__.py
+++ b/hermes/services/__init__.py
@@ -1,6 +1,6 @@
 """External service integrations for Hermes."""
 
-from . import db, llm_interface
+from . import db, llm_interface, reminders
 from .semantic_search import semantic_search
 
-__all__ = ["llm_interface", "db", "semantic_search"]
+__all__ = ["llm_interface", "db", "semantic_search", "reminders"]

--- a/hermes/services/reminders.py
+++ b/hermes/services/reminders.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from .db import list_users, list_reminders, mark_triggered
+
+logger = logging.getLogger(__name__)
+
+_scheduler: BackgroundScheduler | None = None
+
+
+def _alert(message: str) -> None:
+    """Notify the user about a triggered reminder."""
+    try:
+        import pyttsx3
+
+        engine = pyttsx3.init()
+        engine.say(message)
+        engine.runAndWait()
+    except Exception:  # pragma: no cover - best effort
+        logger.info("Reminder: %s", message)
+
+
+def _run_reminder(reminder_id: int, message: str) -> None:
+    """Mark reminder as triggered and alert the user."""
+    mark_triggered(reminder_id)
+    _alert(message)
+
+
+def _schedule_reminder(reminder: dict) -> None:
+    if _scheduler is None:
+        return
+    run_date = datetime.fromisoformat(reminder["trigger_at"])
+    _scheduler.add_job(
+        _run_reminder,
+        "date",
+        run_date=run_date,
+        args=[reminder["id"], reminder["message"]],
+        id=f"reminder-{reminder['id']}",
+        replace_existing=True,
+    )
+
+
+def load_pending_reminders() -> None:
+    """Fetch pending reminders from the database and schedule them."""
+    if _scheduler is None:
+        return
+    for user in list_users():
+        for reminder in list_reminders(user["id"], only_pending=True):
+            _schedule_reminder(reminder)
+
+
+def start_scheduler() -> BackgroundScheduler:
+    """Start the reminder scheduler and load pending reminders."""
+    global _scheduler
+    if _scheduler is not None:
+        return _scheduler
+    _scheduler = BackgroundScheduler()
+    _scheduler.start()
+    load_pending_reminders()
+    return _scheduler

--- a/hermes/ui/cli.py
+++ b/hermes/ui/cli.py
@@ -6,6 +6,7 @@ from ..core.registro_ideias import registrar_ideia_com_llm
 from ..logging import setup_logging
 from ..services.db import add_idea, add_user, init_db, list_ideas, list_users
 from ..services import semantic_search
+from ..services.reminders import start_scheduler
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +103,7 @@ def main(argv: list[str] | None = None):
     setup_logging()
     load_from_args(argv)
     init_db()
+    start_scheduler()
     while True:
         usuario_id = escolher_usuario()
         nome_usuario = next(

--- a/hermes/ui/gui.py
+++ b/hermes/ui/gui.py
@@ -26,6 +26,7 @@ from PyQt5.QtWidgets import (
 from ..core.registro_ideias import analisar_ideia_com_llm, registrar_ideia_com_llm
 from ..data.database import buscar_usuarios, criar_usuario
 from ..services.db import add_idea, list_ideas, update_idea
+from ..services.reminders import start_scheduler
 
 
 class HermesGUI(QWidget):
@@ -259,6 +260,7 @@ class HermesGUI(QWidget):
 
 def main() -> None:
     """Inicia a interface gráfica do Hermes."""
+    start_scheduler()
     app = QApplication(sys.argv)
     gui = HermesGUI()
     gui.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
     "PyQt5>=5.15.9",
     "requests",
+    "apscheduler",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ requests
 fastapi
 "pydantic>=1,<3"
 pyttsx3
+apscheduler
 scikit-learn>=1.1
 vosk==0.3.45  # speech recognition
 


### PR DESCRIPTION
## Summary
- add reminders service to schedule pending reminders and alert users
- load scheduler on app startup via CLI, GUI, API, and module entry point
- declare apscheduler dependency

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install apscheduler` *(fails: No matching distribution found)*
- `pip install fastapi requests` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68c187aded64832cacc196f0a9d517b9