### PR TITLE
Add CLI reminders menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ class MeuIndice(VectorIndex):
 resultado = semantic_search("kanban", index=MeuIndice())
 ```
 
+### Reminders
+
+Agende lembretes simples pelo modo CLI. No menu principal, escolha **Criar
+lembrete** e informe a mensagem e o tempo relativo, como `+1 minute`. Use
+**Listar meus lembretes** para visualizar lembretes pendentes e já
+disparados.
+
 ## Testes
 
 Os testes automatizados utilizam o módulo `unittest` padrão do Python.

--- a/hermes/ui/cli.py
+++ b/hermes/ui/cli.py
@@ -1,12 +1,21 @@
 import logging
 import sys
+from datetime import datetime, timedelta
 
 from ..config import load_from_args
 from ..core.registro_ideias import registrar_ideia_com_llm
 from ..logging import setup_logging
-from ..services.db import add_idea, add_user, init_db, list_ideas, list_users
+from ..services.db import (
+    add_idea,
+    add_reminder,
+    add_user,
+    init_db,
+    list_ideas,
+    list_reminders,
+    list_users,
+)
 from ..services import semantic_search
-from ..services.reminders import start_scheduler
+from ..services.reminders import load_pending_reminders, start_scheduler
 
 logger = logging.getLogger(__name__)
 
@@ -35,14 +44,40 @@ def escolher_usuario():
             logger.error("Digite um número válido.")
 
 
+def _parse_time(expr: str) -> str:
+    """Convert a user-provided time expression to ISO format."""
+    expr = expr.strip()
+    try:
+        if expr.startswith("+"):
+            qty, unit = expr[1:].split(maxsplit=1)
+            amount = int(qty)
+            unit = unit.lower()
+            if unit.startswith("min"):
+                delta = timedelta(minutes=amount)
+            elif unit.startswith("hour") or unit.startswith("hora"):
+                delta = timedelta(hours=amount)
+            elif unit.startswith("day") or unit.startswith("dia"):
+                delta = timedelta(days=amount)
+            else:
+                raise ValueError
+            dt = datetime.utcnow() + delta
+        else:
+            dt = datetime.fromisoformat(expr)
+    except Exception as exc:
+        raise ValueError("formato de tempo inválido") from exc
+    return dt.replace(microsecond=0).isoformat()
+
+
 def menu_principal(usuario_id, nome_usuario):
     while True:
         logger.info("\n=== Hermes (Usuário: %s) ===", nome_usuario)
         logger.info("1. Registrar nova ideia")
         logger.info("2. Listar minhas ideias")
         logger.info("3. Pesquisar ideias")
-        logger.info("4. Trocar de usuário")
-        logger.info("5. Sair")
+        logger.info("4. Criar lembrete")
+        logger.info("5. Listar meus lembretes")
+        logger.info("6. Trocar de usuário")
+        logger.info("7. Sair")
         opcao = input("Escolha uma opção: ")
 
         if opcao == "1":
@@ -91,8 +126,35 @@ def menu_principal(usuario_id, nome_usuario):
             else:
                 logger.info("Nenhuma ideia encontrada.")
         elif opcao == "4":
-            return True  # trocar de usuário
+            mensagem = input("Texto do lembrete: ")
+            quando = input("Quando? (ex: +1 minute): ")
+            try:
+                trigger_at = _parse_time(quando)
+            except ValueError:
+                logger.error("Formato de tempo inválido.")
+                continue
+            add_reminder(usuario_id, mensagem, trigger_at)
+            load_pending_reminders()
+            logger.info("✅ Lembrete agendado para %s.", trigger_at)
         elif opcao == "5":
+            lembretes = list_reminders(usuario_id)
+            pendentes = [r for r in lembretes if r["triggered_at"] is None]
+            disparados = [r for r in lembretes if r["triggered_at"] is not None]
+            if pendentes:
+                logger.info("\nLembretes pendentes:")
+                for r in pendentes:
+                    logger.info("[%s] %s", r["trigger_at"], r["message"])
+            else:
+                logger.info("Nenhum lembrete pendente.")
+            if disparados:
+                logger.info("\nLembretes disparados:")
+                for r in disparados:
+                    logger.info("[%s] %s", r["trigger_at"], r["message"])
+            else:
+                logger.info("Nenhum lembrete disparado.")
+        elif opcao == "6":
+            return True  # trocar de usuário
+        elif opcao == "7":
             logger.info("Encerrando Hermes.")
             return False
         else:


### PR DESCRIPTION
## Summary
- extend CLI with menu options to create and list reminders
- parse relative times like `+1 minute` and schedule reminders immediately
- document reminder usage in README

## Testing
- `python -m black hermes/ui/cli.py`
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'fastapi', 'requests', 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_68c188b69600832cb01fd7483eb347ec