### PR TITLE
Add systemd service and install script for Linux

### DIFF
--- a/packaging/linux/hermes.service
+++ b/packaging/linux/hermes.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Hermes API service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/hermes
+EnvironmentFile=-/etc/default/hermes
+ExecStart=/usr/bin/env python -m hermes.api
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_FILE="hermes.service"
+TARGET="/etc/systemd/system/${SERVICE_FILE}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cp "${SCRIPT_DIR}/${SERVICE_FILE}" "${TARGET}"
+
+systemctl daemon-reload
+systemctl enable hermes
+systemctl start hermes
+


### PR DESCRIPTION
## Summary
- add systemd unit file to run Hermes API
- provide install script that registers and starts the service

## Testing
- `pre-commit run --files packaging/linux/hermes.service packaging/linux/install.sh` *(fails: command not found)*
- `python -m pip install pre-commit` *(fails: could not find a version due to proxy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `bash packaging/linux/install.sh` *(fails: System has not been booted with systemd)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a66d44c0832ca75058b93cc7ba22