### PR TITLE
docs: add platform-specific installation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,60 @@ aplicativo consiga localizar os arquivos offline.
 
 Instale as dependências manualmente caso deseje experimentar esses recursos.
 
+## Instalação Windows
+
+### Dependências mínimas
+
+- Windows 10 ou superior
+- Python 3.11+ com `pip`
+- [PyInstaller](https://pyinstaller.org) (`pip install pyinstaller`)
+
+### Passos
+
+1. Instale as dependências do projeto:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Gere os executáveis com o script de build:
+   ```powershell
+   packaging\windows\build.bat
+   ```
+   Os arquivos `hermes.exe` e `hermes_api.exe` serão criados em `dist\hermes`.
+3. Execute `dist\hermes\hermes.exe` para iniciar a interface.
+
+### Verificação
+
+- A execução de `hermes.exe` deve abrir a interface gráfica.
+
+## Instalação Linux
+
+### Dependências mínimas
+
+- Python 3.11+ com `pip`
+- Sistema com `systemd`
+- `curl` (para verificação)
+
+### Passos
+
+1. Instale as dependências do projeto:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Garanta que o código do Hermes esteja disponível em `/opt/hermes`
+   (ou ajuste `WorkingDirectory` em `hermes.service`).
+3. Instale e ative o serviço:
+   ```bash
+   sudo ./packaging/linux/install.sh
+   ```
+
+### Verificação
+
+- Com o serviço ativo, verifique:
+  ```bash
+  curl localhost:8000/health
+  ```
+  A resposta deve ser `{ "status": "ok" }`.
+
 ## Servidor LLM
 
 Para funcionalidades que usam o modelo de linguagem é necessário que um


### PR DESCRIPTION
## Summary
- document Windows packaging workflow with build script and hermes.exe verification
- document Linux service installation via systemd and health check

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version due to proxy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c1a7b57e9c832c92b59a96ad1bcfb6