### PR TITLE
Store logs under user home with rotating log file

### DIFF
--- a/src/hermes/__main__.py
+++ b/src/hermes/__main__.py
@@ -8,6 +8,7 @@ from .services.reminders import start_scheduler
 
 def main(argv: list[str] | None = None) -> None:
     """Launch the graphical user interface."""
+    # Initialize logging early so the log directory is created
     setup_logging()
     load_from_args(argv)
     start_scheduler()

--- a/src/hermes/logging.py
+++ b/src/hermes/logging.py
@@ -3,7 +3,8 @@ import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
-LOG_DIR = Path(__file__).resolve().parent / "logs"
+# Store logs under the user's home directory
+LOG_DIR = Path.home() / ".hermes" / "logs"
 LOG_FILE = LOG_DIR / "hermes.log"
 
 
@@ -21,7 +22,7 @@ def setup_logging() -> None:
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
-    file_handler = RotatingFileHandler(LOG_FILE, maxBytes=1_000_000, backupCount=3)
+    file_handler = RotatingFileHandler(LOG_FILE, maxBytes=5_000_000, backupCount=5)
     file_handler.setFormatter(formatter)
     stream_handler = logging.StreamHandler(sys.stdout)
     stream_handler.setFormatter(formatter)


### PR DESCRIPTION
## Summary
- log to `~/.hermes/logs/hermes.log`
- rotate log files at 5 MB with five backups
- document early logging setup

## Testing
- `pre-commit run --files src/hermes/logging.py src/hermes/__main__.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install requests fastapi` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d45c2eb0832cb5870d9d70d0af47