### PR TITLE
chore: add pre-commit config and documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v0.4.5
     hooks:
       - id: ruff
+        args: [--fix]
   - repo: https://github.com/psf/black
     rev: 24.3.0
     hooks:
@@ -16,3 +17,5 @@ repos:
     hooks:
       - id: check-toml
         files: ^pyproject\.toml$
+default_language_version:
+  python: python3.11

--- a/README.md
+++ b/README.md
@@ -189,12 +189,14 @@ python -m unittest discover -s tests
 
 ## Desenvolvimento
 
-Instale e configure os linters com [pre-commit](https://pre-commit.com/):
+Instale e configure os linters com [pre-commit](https://pre-commit.com/). Após clonar o repositório, execute:
 
 ```bash
 pip install pre-commit
 pre-commit install
 ```
+
+O comando `pre-commit install` garante que os linters `ruff`, `black` e `isort` sejam executados automaticamente antes de cada commit.
 
 Consulte também [CONTRIBUTING.md](CONTRIBUTING.md) para o fluxo de contribuição,
 [CHANGELOG.md](CHANGELOG.md) para o histórico de mudanças e


### PR DESCRIPTION
## Summary
- configure pre-commit with ruff, black, and isort
- document pre-commit installation for contributors

## Testing
- `pre-commit run -a` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d817dfb0832cbf14e03de432779a