### PR TITLE
chore: sort imports

### DIFF
--- a/src/hermes/__main__.py
+++ b/src/hermes/__main__.py
@@ -2,8 +2,8 @@
 
 from .config import load_from_args
 from .logging import setup_logging
-from .ui import gui
 from .services.reminders import start_scheduler
+from .ui import gui
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/hermes/api.py
+++ b/src/hermes/api.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import os
 import time
-from fastapi import FastAPI, HTTPException, Request, Depends, Header
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from pydantic import BaseModel
 
 from .config import config
 from .services.db import add_idea, init_db
 from .services.llm_interface import gerar_resposta
 from .services.reminders import start_scheduler
-
 
 app = FastAPI()
 

--- a/src/hermes/services/llm_interface.py
+++ b/src/hermes/services/llm_interface.py
@@ -10,7 +10,6 @@ from urllib3.util.retry import Retry
 
 from ..config import config
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/hermes/services/reminders.py
+++ b/src/hermes/services/reminders.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from apscheduler.schedulers.background import BackgroundScheduler
 
-from .db import list_users, list_reminders, mark_triggered
+from .db import list_reminders, list_users, mark_triggered
 
 logger = logging.getLogger(__name__)
 

--- a/src/hermes/ui/cli.py
+++ b/src/hermes/ui/cli.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from ..config import load_from_args
 from ..core.registro_ideias import registrar_ideia_com_llm
 from ..logging import setup_logging
+from ..services import semantic_search
 from ..services.db import (
     add_idea,
     add_reminder,
@@ -14,7 +15,6 @@ from ..services.db import (
     list_reminders,
     list_users,
 )
-from ..services import semantic_search
 from ..services.reminders import load_pending_reminders, start_scheduler
 
 logger = logging.getLogger(__name__)

--- a/src/hermes/ui/gui.py
+++ b/src/hermes/ui/gui.py
@@ -1,15 +1,15 @@
 import csv
 import json
 import sys
-import pyttsx3
 
+import pyttsx3
 import sounddevice as sd
 import vosk
-
 from PyQt5.QtWidgets import (
     QApplication,
     QComboBox,
     QFileDialog,
+    QHBoxLayout,
     QInputDialog,
     QLabel,
     QLineEdit,
@@ -17,7 +17,6 @@ from PyQt5.QtWidgets import (
     QListWidgetItem,
     QMessageBox,
     QPushButton,
-    QHBoxLayout,
     QTextEdit,
     QVBoxLayout,
     QWidget,

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -3,8 +3,8 @@ import unittest
 from unittest.mock import patch
 
 import requests
-import tests.requests_stub  # noqa: F401
 
+import tests.requests_stub  # noqa: F401
 from hermes.services import llm_interface
 
 

--- a/tests/test_llm_script.py
+++ b/tests/test_llm_script.py
@@ -2,8 +2,8 @@ import unittest
 from unittest.mock import patch
 
 import requests
-import tests.requests_stub  # noqa: F401
 
+import tests.requests_stub  # noqa: F401
 from hermes.services.llm_interface import gerar_resposta
 from tests.test_llm_interface import _make_response
 

--- a/tests/test_reminders_scheduler.py
+++ b/tests/test_reminders_scheduler.py
@@ -1,10 +1,11 @@
-from datetime import datetime, timedelta
-import types
-import sys
 import importlib
 import pathlib
+import sys
+import types
+from datetime import datetime, timedelta
 
 import pytest
+
 from tests import requests_stub  # noqa: F401 ensure 'requests' stub
 
 
@@ -51,6 +52,7 @@ services_pkg.__path__ = [
 sys.modules["hermes.services"] = services_pkg
 
 from hermes.config import config
+
 db = importlib.import_module("hermes.services.db")
 reminders = importlib.import_module("hermes.services.reminders")
 

--- a/tests/test_semantic_search.py
+++ b/tests/test_semantic_search.py
@@ -1,10 +1,10 @@
+import sys
+import types
+
 import pytest
 
 # Ensure a 'requests' stub is available before importing hermes.services.
 import tests.requests_stub  # noqa: F401
-
-import sys
-import types
 
 # Stub out 'hermes.services.llm_interface' to avoid heavy dependencies.
 sys.modules.setdefault(
@@ -74,9 +74,9 @@ sys.modules.setdefault("sklearn.feature_extraction.text", text)
 sys.modules.setdefault("sklearn.metrics", metrics)
 sys.modules.setdefault("sklearn.metrics.pairwise", pairwise)
 
-from hermes.services.semantic_search import semantic_search
-from hermes.services import db as dao
 from hermes.data import database
+from hermes.services import db as dao
+from hermes.services.semantic_search import semantic_search
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- group and alphabetize imports in tests and modules
- verify import order with isort check

## Testing
- `isort --check .`
- `pytest tests/test_llm_script.py tests/test_llm_interface.py tests/test_reminders_scheduler.py tests/test_semantic_search.py -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68c2fea2d220832cbcdf243a6438795a