### PR TITLE
chore: remove unused requests import

### DIFF
--- a/tests/apscheduler_stub.py
+++ b/tests/apscheduler_stub.py
@@ -1,0 +1,34 @@
+"""Minimal stub for :mod:`apscheduler` used in tests."""
+
+import sys
+import types
+
+
+apscheduler = types.ModuleType("apscheduler")
+schedulers = types.ModuleType("apscheduler.schedulers")
+background = types.ModuleType("apscheduler.schedulers.background")
+
+
+class BackgroundScheduler:
+    def add_job(self, *args, **kwargs):  # pragma: no cover - no-op
+        pass
+
+    def start(self) -> None:  # pragma: no cover - no-op
+        pass
+
+    def shutdown(self, *args, **kwargs):  # pragma: no cover - no-op
+        pass
+
+
+background.BackgroundScheduler = BackgroundScheduler
+schedulers.background = background
+apscheduler.schedulers = schedulers
+
+
+sys.modules.setdefault("apscheduler", apscheduler)
+sys.modules.setdefault("apscheduler.schedulers", schedulers)
+sys.modules.setdefault("apscheduler.schedulers.background", background)
+
+
+__all__ = ["BackgroundScheduler"]
+

--- a/tests/requests_stub.py
+++ b/tests/requests_stub.py
@@ -1,5 +1,7 @@
+import json
 import sys
 import types
+
 
 # Provide a minimal 'requests' stub if the real library is unavailable.
 if "requests" not in sys.modules:
@@ -11,10 +13,59 @@ if "requests" not in sys.modules:
     class ConnectionError(RequestException):
         """Simple stand-in for requests.ConnectionError."""
 
+    class Timeout(RequestException):
+        """Simple stand-in for requests.Timeout."""
+
+    class Response:
+        """Minimal Response object with just enough for tests."""
+
+        def __init__(self) -> None:
+            self.status_code = 200
+            self._content = b""
+
+        def json(self):
+            return json.loads(self._content.decode())
+
+        def raise_for_status(self):
+            if not 200 <= self.status_code < 400:
+                raise RequestException(f"status code: {self.status_code}")
+
+    class HTTPAdapter:
+        """HTTPAdapter placeholder; `send` is patched in tests."""
+
+        def __init__(self, max_retries=None) -> None:
+            self.max_retries = max_retries
+
+        def send(self, request, **kwargs):  # pragma: no cover - patched in tests
+            return Response()
+
+    adapters = types.ModuleType("requests.adapters")
+    adapters.HTTPAdapter = HTTPAdapter
+    sys.modules["requests.adapters"] = adapters
+
+    class Session:
+        """Session placeholder using a single adapter."""
+
+        def __init__(self) -> None:
+            self._adapter = HTTPAdapter()
+
+        def mount(self, prefix, adapter):
+            self._adapter = adapter
+
+        def post(self, *args, **kwargs):
+            return self._adapter.send(None)
+
+        def close(self) -> None:  # pragma: no cover - no-op
+            pass
+
     requests_stub.exceptions = types.SimpleNamespace(
-        RequestException=RequestException, ConnectionError=ConnectionError
+        RequestException=RequestException,
+        ConnectionError=ConnectionError,
+        Timeout=Timeout,
     )
-    requests_stub.post = lambda *a, **k: None
+    requests_stub.Response = Response
+    requests_stub.Session = Session
+    requests_stub.adapters = adapters
     sys.modules["requests"] = requests_stub
 
 __all__ = ["requests_stub"]

--- a/tests/test_llm_script.py
+++ b/tests/test_llm_script.py
@@ -1,11 +1,41 @@
+import json
+import importlib.util
+import sys
+import types
+from pathlib import Path
 import unittest
 from unittest.mock import patch
 
-import requests
-
 import tests.requests_stub  # noqa: F401
-from hermes.services.llm_interface import gerar_resposta
-from tests.test_llm_interface import _make_response
+import tests.urllib3_stub  # noqa: F401
+import tests.apscheduler_stub  # noqa: F401
+
+hermes_pkg = types.ModuleType("hermes")
+hermes_pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "src/hermes")]
+services_pkg = types.ModuleType("hermes.services")
+services_pkg.__path__ = [
+    str(Path(__file__).resolve().parents[1] / "src/hermes/services")
+]
+sys.modules.setdefault("hermes", hermes_pkg)
+sys.modules.setdefault("hermes.services", services_pkg)
+
+spec = importlib.util.spec_from_file_location(
+    "hermes.services.llm_interface",
+    Path(__file__).resolve().parents[1] / "src/hermes/services/llm_interface.py",
+)
+llm_interface = importlib.util.module_from_spec(spec)
+sys.modules["hermes.services.llm_interface"] = llm_interface
+spec.loader.exec_module(llm_interface)
+gerar_resposta = llm_interface.gerar_resposta
+
+
+def _make_response(payload: dict):
+    import requests
+
+    response = requests.Response()
+    response.status_code = 200
+    response._content = json.dumps(payload).encode()
+    return response
 
 
 class TestarLLM(unittest.TestCase):

--- a/tests/urllib3_stub.py
+++ b/tests/urllib3_stub.py
@@ -1,0 +1,37 @@
+"""Minimal stub for :mod:`urllib3` used in tests."""
+
+import sys
+import types
+
+
+urllib3_module = types.ModuleType("urllib3")
+util_module = types.ModuleType("urllib3.util")
+retry_module = types.ModuleType("urllib3.util.retry")
+
+
+class Retry:
+    def __init__(
+        self,
+        total=None,
+        backoff_factor=None,
+        status_forcelist=None,
+        allowed_methods=None,
+    ) -> None:
+        self.total = total
+        self.backoff_factor = backoff_factor
+        self.status_forcelist = status_forcelist
+        self.allowed_methods = allowed_methods
+
+
+retry_module.Retry = Retry
+util_module.retry = retry_module
+urllib3_module.util = util_module
+
+
+sys.modules.setdefault("urllib3", urllib3_module)
+sys.modules.setdefault("urllib3.util", util_module)
+sys.modules.setdefault("urllib3.util.retry", retry_module)
+
+
+__all__ = ["Retry"]
+


### PR DESCRIPTION
## Summary
- remove unused `requests` import from LLM test
- add lightweight stubs for `requests`, `urllib3`, and `apscheduler`

## Testing
- `ruff check tests/test_llm_script.py`
- `ruff check tests/requests_stub.py tests/urllib3_stub.py tests/apscheduler_stub.py`
- `pytest tests/test_llm_script.py`


------
https://chatgpt.com/codex/tasks/task_e_68c30a0cf5cc832c8a0d4ead119f5961