### PR TITLE
Refine idea context heuristic

### DIFF
--- a/src/hermes/assistant/engine.py
+++ b/src/hermes/assistant/engine.py
@@ -25,6 +25,23 @@ _TERMOS_SOLICITACAO_EXTERNA = {
     "quais as noticias",
     "quais as notícias",
 }
+
+_TERMOS_CONTEXTO_IDEIAS = {
+    "ideia",
+    "ideias",
+    "projeto",
+    "projetos",
+    "plano",
+    "planos",
+    "planejamento",
+    "prioridade",
+    "prioridades",
+    "priorizacao",
+    "priorização",
+    "organizacao de pensamentos",
+    "organizar pensamentos",
+    "organizar ideias",
+}
 _RESPOSTA_OFFLINE_PADRAO = (
     "Não tenho acesso ao mundo externo ou à internet. "
     "Posso, porém, te ajudar a planejar o dia com base nas suas ideias e tarefas."
@@ -46,22 +63,16 @@ def _solicitacao_requer_mundo_externo(mensagem: str) -> bool:
 
 
 def _deve_usar_contexto_ideias(mensagem: str) -> bool:
-    termos_chave = {
-        "ideia",
-        "ideias",
-        "projeto",
-        "projetos",
-        "plano",
-        "planos",
-        "prioridade",
-        "prioridades",
-        "organizacao de pensamentos",
-        "organizar pensamentos",
-        "organizar ideias",
-    }
+    """Retorna True se a mensagem provavelmente se refere a ideias/projetos/planejamento."""
 
     texto_normalizado = _normalizar_texto(mensagem)
-    return any(termo in texto_normalizado for termo in termos_chave)
+    usar_contexto = any(
+        termo in texto_normalizado for termo in _TERMOS_CONTEXTO_IDEIAS
+    )
+    logger.debug(
+        "Usando contexto de ideias? %s (mensagem='%s')", usar_contexto, mensagem
+    )
+    return usar_contexto
 
 
 def _registrar_no_historico(state: ConversationState | None, mensagem: str, resposta: str) -> None:

--- a/tests/test_assistant_engine.py
+++ b/tests/test_assistant_engine.py
@@ -97,7 +97,11 @@ class AssistantEngineTests(unittest.TestCase):
         self.assertTrue(
             engine._deve_usar_contexto_ideias("Quais são minhas prioridades e planos?")
         )
+        self.assertTrue(
+            engine._deve_usar_contexto_ideias("Podemos fazer um planejamento para este projeto?")
+        )
         self.assertFalse(engine._deve_usar_contexto_ideias("Conte uma piada"))
+        self.assertFalse(engine._deve_usar_contexto_ideias("Quem é você?"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- centralize and document the idea context heuristic with configurable keywords
- add debug logging to trace when idea context is used
- expand heuristic test coverage to include planning prompts and generic questions

## Testing
- python -m pytest tests/test_assistant_engine.py *(fails: ModuleNotFoundError: No module named 'vosk')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693afe9e1af0832c8bb0768ad40716d1)